### PR TITLE
fix: raise a clear error when log2FC has no cells to compare against

### DIFF
--- a/src/liana/method/sc/_liana_pipe.py
+++ b/src/liana/method/sc/_liana_pipe.py
@@ -369,6 +369,15 @@ def _calc_log2fc(adata, label) -> np.ndarray:
     subject = adata[adata.obs[I.label].isin([label])]
     rest = adata[~adata.obs[I.label].isin([label])]
 
+    if rest.n_obs == 0:
+        raise ValueError(
+            f"Cannot compute log2FC for group '{label}': every cell belongs to it, "
+            "leaving no cells to compare against. This typically happens when "
+            "`sample_key` splits the data such that a sample contains only a single "
+            "`groupby` category. Ensure each `sample_key` group contains more than "
+            "one `groupby` category."
+        )
+
     # subject and rest means
     subj_means = subject.layers['normcounts'].mean(0).A.flatten()
     rest_means = rest.layers['normcounts'].mean(0).A.flatten()

--- a/tests/test_liana_pipe.py
+++ b/tests/test_liana_pipe.py
@@ -2,6 +2,7 @@ import pathlib
 from itertools import product
 
 import numpy as np
+import pytest
 from pandas import DataFrame, read_csv
 from pandas.testing import assert_frame_equal
 from scanpy.datasets import pbmc68k_reduced
@@ -117,3 +118,18 @@ def test_calc_log2fc():
     adata.layers['normcounts'].data = _expm1_base(V.logbase, adata.raw.X.data)
     adata.obs['@label'] = adata.obs.bulk_labels
     np.testing.assert_almost_equal(np.mean(_calc_log2fc(adata, "Dendritic")), -0.123781264)
+
+
+def test_calc_log2fc_no_rest_raises():
+    # https://github.com/saezlab/liana-py/issues/93
+    # If every cell belongs to the same `groupby` label (e.g. a `sample_key`
+    # split that happens to contain a single category), there's no "rest" of
+    # cells left to compare against, and this used to raise a cryptic
+    # ZeroDivisionError deep in scipy's sparse mean() instead of a clear error.
+    single_label = adata[adata.obs.bulk_labels == "Dendritic"].copy()
+    single_label.layers['normcounts'] = single_label.raw.X.copy()
+    single_label.layers['normcounts'].data = _expm1_base(V.logbase, single_label.raw.X.data)
+    single_label.obs['@label'] = single_label.obs.bulk_labels
+
+    with pytest.raises(ValueError, match="Cannot compute log2FC"):
+        _calc_log2fc(single_label, "Dendritic")


### PR DESCRIPTION
Fixes #93

`_calc_log2fc` splits cells into `subject` (the current group) vs `rest` (everything else), then computes `rest.layers['normcounts'].mean(0)`. If a `sample_key` group happens to contain only one `groupby` category, `rest` ends up with 0 rows, and scipy's sparse `mean()` divides by that empty shape, surfacing as a bare `ZeroDivisionError` deep in scipy internals with no useful context, exactly matching the traceback in the issue and nrclaudio's later diagnosis in the same thread.

Raises a `ValueError` explaining the actual cause (no cells left to compare against, usually a `sample_key`/`groupby` combination issue) instead of letting scipy's error leak through.

### Testing

Added `test_calc_log2fc_no_rest_raises`, which reproduces the empty-rest condition directly against the existing `pbmc68k_reduced` fixture. `tests/test_liana_pipe.py` (6/6), `tests/test_rank_aggregate.py` + `tests/test_sc_methods.py` (20/20, includes `by_sample` and mdata paths) all pass in a fresh Python 3.12 container.