### PR TITLE
Fetch the datasets from exampledata.scverse.org

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -190,6 +190,10 @@ Passed as `model=` when calling a `MistyData` object:
     :toctree: generated
 
     kang_2018
+    kuppe_2022
+    citeseq_pbmc5k
+    vicari_2024
+    yao_2023
     generate_toy_adata
     generate_toy_spatial
     generate_toy_mdata

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ dependencies = [
   "pandas",
   "plotnine>=0.10.1",
   "scanpy>=1.12",                  # 1.12 guards `annotate_doc_types` against non-weakref-able TypeAliasType
-  "scverse-misc[datasets]>=0.1.4", # declarative dataset registry + pooch downloads behind `li.ds`
+  "scverse-misc[datasets]>=0.1.4",
   "session-info2",
   "tqdm>=4",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,8 @@ dependencies = [
   "numba",
   "pandas",
   "plotnine>=0.10.1",
-  "scanpy>=1.12",     # 1.12 guards `annotate_doc_types` against non-weakref-able TypeAliasType
+  "scanpy>=1.12",                  # 1.12 guards `annotate_doc_types` against non-weakref-able TypeAliasType
+  "scverse-misc[datasets]>=0.1.4", # declarative dataset registry + pooch downloads behind `li.ds`
   "session-info2",
   "tqdm>=4",
 ]

--- a/src/liana/datasets/__init__.py
+++ b/src/liana/datasets/__init__.py
@@ -1,11 +1,15 @@
 from ._sample_anndata import generate_toy_adata, generate_toy_mdata, generate_toy_spatial
 from ._sample_lrs import sample_lrs
-from .datasets import kang_2018
+from .datasets import citeseq_pbmc5k, kang_2018, kuppe_2022, vicari_2024, yao_2023
 
 __all__ = [
+    "citeseq_pbmc5k",
     "generate_toy_adata",
     "generate_toy_mdata",
     "generate_toy_spatial",
     "kang_2018",
+    "kuppe_2022",
     "sample_lrs",
+    "vicari_2024",
+    "yao_2023",
 ]

--- a/src/liana/datasets/_fetch.py
+++ b/src/liana/datasets/_fetch.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+from functools import cache
+from importlib.resources import as_file, files
+from typing import TYPE_CHECKING, cast
+
+import scanpy as sc
+from scverse_misc.datasets import fetch, parse_registry, register_loader
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from anndata import AnnData
+    from mudata import MuData
+    from scverse_misc.datasets import DatasetEntry, DownloadCB
+
+
+@register_loader("mudata")
+def _load_mudata(entry: DatasetEntry, target: Path, download: DownloadCB, /, **kwargs: object) -> MuData:
+    """Download the `.h5ad` file of each modality of `entry` and assemble them into a :class:`~mudata.MuData`.
+
+    The modality names are taken from the entry's `modalities` metadata, which maps each modality to the file it is read from.
+    """
+    import anndata as ad
+    from mudata import MuData
+
+    if kwargs:
+        raise TypeError(f"Unexpected keyword arguments: {sorted(kwargs)}")
+
+    modalities = cast("dict[str, str]", entry.metadata["modalities"])
+    return MuData({mod: ad.read_h5ad(download(entry.file(name=filename))) for mod, filename in modalities.items()})
+
+
+@cache
+def _registry() -> tuple[str | None, dict[str, DatasetEntry]]:
+    with as_file(files(__package__) / "registry.yaml") as path:
+        return parse_registry(path)
+
+
+def fetch_dataset(name: str) -> AnnData | MuData:
+    """Download `name` into :attr:`scanpy.settings.datasetdir` if it is not cached there yet, and read it."""
+    base_url, datasets = _registry()
+    sc.settings.datasetdir.mkdir(parents=True, exist_ok=True)
+    return fetch(datasets[name], sc.settings.datasetdir, base_url=base_url)

--- a/src/liana/datasets/datasets.py
+++ b/src/liana/datasets/datasets.py
@@ -33,7 +33,6 @@ def kang_2018() -> AnnData:
         adata = li.ds.kang_2018()
 
     The resulting object carries `obs['sample']`, `obs['condition']`, `obs['patient']` and `obs['cell_abbr']`, and is the starting point of several tutorials.
-
     """
     adata = cast("AnnData", fetch_dataset("kang_2018"))
 
@@ -82,7 +81,6 @@ def kuppe_2022() -> AnnData:
         adata = li.ds.kuppe_2022()
 
     It is the slide used in the bivariate metrics and MISTy tutorials.
-
     """
     return cast("AnnData", fetch_dataset("kuppe_2022"))
 
@@ -107,7 +105,6 @@ def citeseq_pbmc5k() -> MuData:
         rna, prot = mdata.mod["rna"], mdata.mod["prot"]
 
     It is the dataset used in the multi-modal ligand-receptor tutorial.
-
     """
     return cast("MuData", fetch_dataset("citeseq_pbmc5k"))
 
@@ -133,7 +130,6 @@ def vicari_2024() -> MuData:
 
         mdata = li.ds.vicari_2024()
         rna, msi, ct = mdata.mod["rna"], mdata.mod["msi"], mdata.mod["ct"]
-
     """
     return cast("MuData", fetch_dataset("vicari_2024"))
 
@@ -160,6 +156,5 @@ def yao_2023() -> AnnData:
         adata = li.ds.yao_2023()
 
     It is the dataset used in the inflow and LRIC tutorials.
-
     """
     return cast("AnnData", fetch_dataset("yao_2023"))

--- a/src/liana/datasets/datasets.py
+++ b/src/liana/datasets/datasets.py
@@ -1,13 +1,13 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
-
-import scanpy as sc
+from typing import TYPE_CHECKING, cast
 
 from liana._core._types import get_obs, get_x
+from liana.datasets._fetch import fetch_dataset
 
 if TYPE_CHECKING:
     from anndata import AnnData
+    from mudata import MuData
 
 
 def kang_2018() -> AnnData:
@@ -15,7 +15,7 @@ def kang_2018() -> AnnData:
     Utility function to load the data from Kang et al., 2018; GSE96583.
 
     The data contains ~25k PBMCs cells from 8 pooled patient lupus samples, each before and after IFN-beta stimulation.
-    Kang, H., Subramaniam, M., Targ, S. et al. Multiplexed droplet single-cell RNA-sequencing using natural genetic variation. Nat Biotechnol 36, 89–94 (2018). https://doi.org/10.1038/nbt.4042
+    Kang, H., Subramaniam, M., Targ, S. et al. Multiplexed droplet single-cell RNA-sequencing using natural genetic variation. Nat Biotechnol 36, 89-94 (2018). https://doi.org/10.1038/nbt.4042
 
     The dataset was preprocessed for and is available via pertpy (https://github.com/theislab/pertpy; Heumos et al., In prep.).
 
@@ -26,19 +26,16 @@ def kang_2018() -> AnnData:
 
     Examples
     --------
-    This downloads ~200MB from figshare on first call (and caches it in the
-    working directory), so it is not run here::
+    This downloads ~40MB into :attr:`scanpy.settings.datasetdir` on first call, so it is not run here::
 
         import liana as li
 
         adata = li.ds.kang_2018()
 
-    The resulting object carries `obs['sample']`, `obs['condition']`,
-    `obs['patient']` and `obs['cell_abbr']`, and is the starting point of several
-    tutorials.
+    The resulting object carries `obs['sample']`, `obs['condition']`, `obs['patient']` and `obs['cell_abbr']`, and is the starting point of several tutorials.
 
     """
-    adata = sc.read("kang_counts_25k.h5ad", backup_url="https://figshare.com/ndownloader/files/34464122")
+    adata = cast("AnnData", fetch_dataset("kang_2018"))
 
     # Store the counts for later use
     adata.layers["counts"] = get_x(adata).copy()
@@ -63,3 +60,106 @@ def kang_2018() -> AnnData:
     obs["cell_abbr"] = obs["cell_type"].replace(abbreviations)
 
     return adata
+
+
+def kuppe_2022() -> AnnData:
+    """
+    Utility function to load a single 10X Visium slide from Kuppe et al., 2022.
+
+    The slide (`Visium_19_CK297`) is taken from the ischemic zone of the heart of a patient with myocardial infarction.
+    Kuppe, C., Ramirez Flores, R.O., Li, Z. et al. Spatial multi-omic map of human myocardial infarction. Nature 608, 766-777 (2022). https://doi.org/10.1038/s41586-022-05060-x
+
+    Returns
+    -------
+    Returns an AnnData object with raw counts for ~4k spots, along with the spatial coordinates in `obsm['spatial']` and the cell type compositions of each spot in `obsm['compositions']`.
+
+    Examples
+    --------
+    This downloads ~45MB into :attr:`scanpy.settings.datasetdir` on first call, so it is not run here::
+
+        import liana as li
+
+        adata = li.ds.kuppe_2022()
+
+    It is the slide used in the bivariate metrics and MISTy tutorials.
+
+    """
+    return cast("AnnData", fetch_dataset("kuppe_2022"))
+
+
+def citeseq_pbmc5k() -> MuData:
+    """
+    Utility function to load the processed 10X 5k PBMC CITE-seq data.
+
+    The RNA and protein modalities were processed following the muon CITE-seq tutorial (https://muon-tutorials.readthedocs.io/en/latest/cite-seq/1-CITE-seq-PBMC-5k.html).
+
+    Returns
+    -------
+    Returns a MuData object with a pre-processed `mod['rna']` and `mod['prot']` modality, with the cell type annotations of the 3.9k shared cells in `mod['rna'].obs['celltype']`.
+
+    Examples
+    --------
+    This downloads ~80MB into :attr:`scanpy.settings.datasetdir` on first call, so it is not run here::
+
+        import liana as li
+
+        mdata = li.ds.citeseq_pbmc5k()
+        rna, prot = mdata.mod["rna"], mdata.mod["prot"]
+
+    It is the dataset used in the multi-modal ligand-receptor tutorial.
+
+    """
+    return cast("MuData", fetch_dataset("citeseq_pbmc5k"))
+
+
+def vicari_2024() -> MuData:
+    """
+    Utility function to load a single spatial multimodal analysis (SMA) slide from Vicari et al., 2024.
+
+    The slide comes from a murine Parkinson's disease model, in which one hemisphere was subjected to unilateral 6-hydroxydopamine-induced lesions while the other remained intact.
+    Vicari, M., Mirzazadeh, R., Nilsson, A. et al. Spatial multimodal analysis of transcriptomes and metabolomes in tissues. Nat Biotechnol 42, 1046-1050 (2024). https://doi.org/10.1038/s41587-023-01937-y
+
+    Returns
+    -------
+    Returns a MuData object with three modalities of the same slide:
+    `mod['rna']` with log1p-transformed 10X Visium counts, `mod['msi']` with total-ion-count-normalised MALDI-MSI peaks, and `mod['ct']` with the Tangram cell type proportions of the RNA modality.
+    The MSI observations are not aligned to the Visium spots; aligning them is part of the corresponding tutorial.
+
+    Examples
+    --------
+    This downloads ~165MB into :attr:`scanpy.settings.datasetdir` on first call, so it is not run here::
+
+        import liana as li
+
+        mdata = li.ds.vicari_2024()
+        rna, msi, ct = mdata.mod["rna"], mdata.mod["msi"], mdata.mod["ct"]
+
+    """
+    return cast("MuData", fetch_dataset("vicari_2024"))
+
+
+def yao_2023() -> AnnData:
+    """
+    Utility function to load the `WB_MERFISH_animal2_coronal` slide of the whole mouse brain atlas from Yao et al., 2023.
+
+    The data was generated with MERFISH, which profiles the expression of more than 1,000 genes at subcellular spatial resolution.
+    Yao, Z., van Velthoven, C.T.J., Kunst, M. et al. A high-resolution transcriptomic and spatial atlas of cell types in the whole mouse brain. Nature 624, 317-332 (2023). https://doi.org/10.1038/s41586-023-06808-9
+
+    The object is the CELLxGENE release of the dataset (https://cellxgene.cziscience.com/collections/0cca8620-8dee-45d0-aef5-23f032a5cf09).
+
+    Returns
+    -------
+    Returns the AnnData object as released on CELLxGENE: ~4M cells; ~1.1k genes indexed by Ensembl ID (with symbols in `var['gene_name']`), cell type annotations in `obs`, and the spatial coordinates in `obsm['spatial']`.
+
+    Examples
+    --------
+    This downloads ~1GB into :attr:`scanpy.settings.datasetdir` on first call, so it is not run here::
+
+        import liana as li
+
+        adata = li.ds.yao_2023()
+
+    It is the dataset used in the inflow and LRIC tutorials.
+
+    """
+    return cast("AnnData", fetch_dataset("yao_2023"))

--- a/src/liana/datasets/datasets.py
+++ b/src/liana/datasets/datasets.py
@@ -12,7 +12,7 @@ if TYPE_CHECKING:
 
 def kang_2018() -> AnnData:
     """
-    Utility function to load the data from Kang et al., 2018; GSE96583.
+    Load the data from Kang et al., 2018; GSE96583.
 
     The data contains ~25k PBMCs cells from 8 pooled patient lupus samples, each before and after IFN-beta stimulation.
     Kang, H., Subramaniam, M., Targ, S. et al. Multiplexed droplet single-cell RNA-sequencing using natural genetic variation. Nat Biotechnol 36, 89-94 (2018). https://doi.org/10.1038/nbt.4042
@@ -64,7 +64,7 @@ def kang_2018() -> AnnData:
 
 def kuppe_2022() -> AnnData:
     """
-    Utility function to load a single 10X Visium slide from Kuppe et al., 2022.
+    Load a single 10X Visium slide from Kuppe et al., 2022.
 
     The slide (`Visium_19_CK297`) is taken from the ischemic zone of the heart of a patient with myocardial infarction.
     Kuppe, C., Ramirez Flores, R.O., Li, Z. et al. Spatial multi-omic map of human myocardial infarction. Nature 608, 766-777 (2022). https://doi.org/10.1038/s41586-022-05060-x
@@ -89,7 +89,7 @@ def kuppe_2022() -> AnnData:
 
 def citeseq_pbmc5k() -> MuData:
     """
-    Utility function to load the processed 10X 5k PBMC CITE-seq data.
+    Load the processed 10X 5k PBMC CITE-seq data.
 
     The RNA and protein modalities were processed following the muon CITE-seq tutorial (https://muon-tutorials.readthedocs.io/en/latest/cite-seq/1-CITE-seq-PBMC-5k.html).
 
@@ -114,7 +114,7 @@ def citeseq_pbmc5k() -> MuData:
 
 def vicari_2024() -> MuData:
     """
-    Utility function to load a single spatial multimodal analysis (SMA) slide from Vicari et al., 2024.
+    Load a single spatial multimodal analysis (SMA) slide from Vicari et al., 2024.
 
     The slide comes from a murine Parkinson's disease model, in which one hemisphere was subjected to unilateral 6-hydroxydopamine-induced lesions while the other remained intact.
     Vicari, M., Mirzazadeh, R., Nilsson, A. et al. Spatial multimodal analysis of transcriptomes and metabolomes in tissues. Nat Biotechnol 42, 1046-1050 (2024). https://doi.org/10.1038/s41587-023-01937-y
@@ -140,7 +140,7 @@ def vicari_2024() -> MuData:
 
 def yao_2023() -> AnnData:
     """
-    Utility function to load the `WB_MERFISH_animal2_coronal` slide of the whole mouse brain atlas from Yao et al., 2023.
+    Load the `WB_MERFISH_animal2_coronal` slide of the whole mouse brain atlas from Yao et al., 2023.
 
     The data was generated with MERFISH, which profiles the expression of more than 1,000 genes at subcellular spatial resolution.
     Yao, Z., van Velthoven, C.T.J., Kunst, M. et al. A high-resolution transcriptomic and spatial atlas of cell types in the whole mouse brain. Nature 624, 317-332 (2023). https://doi.org/10.1038/s41586-023-06808-9

--- a/src/liana/datasets/registry.yaml
+++ b/src/liana/datasets/registry.yaml
@@ -1,0 +1,77 @@
+# Datasets LIANA+ hosts itself, fetched via `scverse_misc.datasets.fetch`.
+#
+# Add a `sha256` for every file: it is what lets a truncated or corrupted
+# download be detected (and retried) instead of surfacing as a parse error.
+#
+# `fallback_urls` are the upstream locations the tutorials used before the
+# scverse bucket; they are used if the bucket is down or serves garbage.
+base_url: https://exampledata.scverse.org/liana
+
+datasets:
+
+  kang_2018:
+    type: anndata
+    files:
+      - name: kang.h5ad
+        s3_key: kang.h5ad
+        sha256: e6a5adac64dcdeb36eaba27db49b63e0c64bb0ed4a64c6705971506b41c39830
+        fallback_urls:
+          - https://figshare.com/ndownloader/files/34464122
+
+  kuppe_2022:
+    type: anndata
+    files:
+      - name: Visium_19_CK297.h5ad
+        s3_key: Visium_19_CK297.h5ad
+        sha256: 95b7f921f12bfcc92a7135854063ece4647ab75756a14a0021a9fb0b8bfe934c
+        fallback_urls:
+          - https://figshare.com/ndownloader/files/41501073?private_link=4744950f8768d5c8f68c
+
+  citeseq_pbmc5k:
+    type: mudata
+    modalities:
+      rna: citeseq_rna.h5ad
+      prot: citeseq_prot.h5ad
+    files:
+      - name: citeseq_rna.h5ad
+        s3_key: citeseq_rna.h5ad
+        sha256: aae188ddf1b1e57e5899c1be1ea742afa94680c2ffa6a0fa427a237664390c51
+        fallback_urls:
+          - https://figshare.com/ndownloader/files/47625193
+      - name: citeseq_prot.h5ad
+        s3_key: citeseq_prot.h5ad
+        sha256: 1091b062b4c4baf4c5ffdd3ad36eb6816d2d3eb1248c1f417fb7eff6ffa9cc81
+        fallback_urls:
+          - https://figshare.com/ndownloader/files/47625196
+
+  vicari_2024:
+    type: mudata
+    modalities:
+      rna: sma_rna.h5ad
+      msi: sma_msi.h5ad
+      ct: sma_deconv.h5ad
+    files:
+      - name: sma_rna.h5ad
+        s3_key: sma_rna.h5ad
+        sha256: 4fd66594dc1411b489a11f890c3e84332611ac6757e54420ec0a3012e9679b13
+        fallback_urls:
+          - https://figshare.com/ndownloader/files/44624974?private_link=4744950f8768d5c8f68c
+      - name: sma_msi.h5ad
+        s3_key: sma_msi.h5ad
+        sha256: 735d7bee1d82bdf829771457b8d350c8ada5a7832cb4571627272338fd92e124
+        fallback_urls:
+          - https://figshare.com/ndownloader/files/44624971?private_link=4744950f8768d5c8f68c
+      - name: sma_deconv.h5ad
+        s3_key: sma_deconv.h5ad
+        sha256: c9f760c7826061fe92b0dd69f90ef1d4958128bf31f20e8851ebdc1b98af0c96
+        fallback_urls:
+          - https://figshare.com/ndownloader/files/44624968?private_link=4744950f8768d5c8f68c
+
+  yao_2023:
+    type: anndata
+    files:
+      - name: WB_MERFISH_animal2_coronal.h5ad
+        s3_key: 93c3bb97-ea05-4ee0-a760-a1508cd04612.h5ad
+        sha256: fd02ea1a11444310ef537c42c5aa3b27b6a7fb2f314d9105207b6b5b64b27ec5
+        fallback_urls:
+          - https://datasets.cellxgene.cziscience.com/93c3bb97-ea05-4ee0-a760-a1508cd04612.h5ad

--- a/src/liana/datasets/registry.yaml
+++ b/src/liana/datasets/registry.yaml
@@ -1,10 +1,8 @@
 # Datasets LIANA+ hosts itself, fetched via `scverse_misc.datasets.fetch`.
 #
-# Add a `sha256` for every file: it is what lets a truncated or corrupted
-# download be detected (and retried) instead of surfacing as a parse error.
+# Add a `sha256` for every file: it is what lets a truncated or corrupted download be detected (and retried) instead of surfacing as a parse error.
 #
-# `fallback_urls` are the upstream locations the tutorials used before the
-# scverse bucket; they are used if the bucket is down or serves garbage.
+# `fallback_urls` are the upstream locations the tutorials used before the scverse bucket; they are used if the bucket is down or serves garbage.
 base_url: https://exampledata.scverse.org/liana
 
 datasets:

--- a/tests/test_datasets_registry.py
+++ b/tests/test_datasets_registry.py
@@ -1,0 +1,30 @@
+from urllib.parse import urlparse
+
+import pytest
+
+import liana as li
+from liana.datasets._fetch import _registry
+
+
+def test_registry_base_url() -> None:
+    base_url, _ = _registry()
+    assert base_url == "https://exampledata.scverse.org/liana"
+
+
+@pytest.mark.parametrize("name", _registry()[1])
+def test_registry_entry(name: str) -> None:
+    base_url, datasets = _registry()
+    entry = datasets[name]
+    # every dataset is exposed under the function of the same name
+    assert callable(getattr(li.ds, name))
+    assert entry.type in {"anndata", "mudata"}
+    assert entry.files
+    for file in entry.files:
+        # a sha256 is what lets a truncated download be detected instead of surfacing as a parse error
+        assert file.sha256, f"{name}/{file.name} is missing a sha256"
+        for url in [file.resolve_url(base_url), *(file.fallback_urls or [])]:
+            assert urlparse(url).scheme in {"http", "https", "ftp"}
+    if entry.type == "mudata":
+        modalities = entry.metadata["modalities"]
+        filenames = {file.name for file in entry.files}
+        assert set(modalities.values()) == filenames


### PR DESCRIPTION
Moves every dataset used by liana off the dead figshare links onto https://exampledata.scverse.org/liana, fetched via a `registry.yaml` that `scverse_misc.datasets.fetch` resolves with sha256 verification and figshare/cellxgene fallbacks.
`li.ds` now also exposes `kuppe_2022`, `citeseq_pbmc5k`, `vicari_2024` and `yao_2023`, which the tutorials used to download by URL (scverse/liana-tutorials#2).

Closes #233