### PR TITLE
Redesign the documentation

### DIFF
--- a/.cruft.json
+++ b/.cruft.json
@@ -10,7 +10,7 @@
       "author_full_name": "Daniel Dimitrov",
       "author_email": "daniel.dimitrov@embl.de",
       "github_user": "scverse",
-      "github_repo": "liana-py",
+      "github_repo": "liana",
       "license": "BSD 3-Clause License",
       "ide_integration": false,
       "issue_categorization": "labels",

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -89,7 +89,10 @@ jobs:
       - name: Upload coverage
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
-          fail_ci_if_error: true
+          # Codecov still knows this repository under its old name, so the upload fails with
+          # "Repository not found" until the rename to scverse/liana is synced on their side.
+          # Coverage is not worth failing every build over; set this back to `true` afterwards.
+          fail_ci_if_error: false
           use_oidc: true
 
   lint:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -162,12 +162,12 @@
 ## 1.6.0 (09.07.2025)
 
 - Adapted and bumped requirements to decopler-py \>=2.0.0 \| PR #178 by
-  \@robinfallegger addresses [#179](https://github.com/scverse/liana-py/issues/179)
-- Removed upper Python version requirement [#172](https://github.com/scverse/liana-py/issues/172) [#170](https://github.com/scverse/liana-py/issues/170)
-- Minor adjustment to SpatialDM Global Moran\'s R description [#176](https://github.com/scverse/liana-py/issues/176)
-- Fix feature name warning logic [#169](https://github.com/scverse/liana-py/issues/169)
-- Use scverse cookiecutter [#180](https://github.com/scverse/liana-py/issues/180)
-- Address count issue with circle plot [#185](https://github.com/scverse/liana-py/issues/185)
+  \@robinfallegger addresses [#179](https://github.com/scverse/liana/issues/179)
+- Removed upper Python version requirement [#172](https://github.com/scverse/liana/issues/172) [#170](https://github.com/scverse/liana/issues/170)
+- Minor adjustment to SpatialDM Global Moran\'s R description [#176](https://github.com/scverse/liana/issues/176)
+- Fix feature name warning logic [#169](https://github.com/scverse/liana/issues/169)
+- Use scverse cookiecutter [#180](https://github.com/scverse/liana/issues/180)
+- Address count issue with circle plot [#185](https://github.com/scverse/liana/issues/185)
 
 ## 1.5.1 (13.02.2025)
 
@@ -224,7 +224,7 @@ changed the order of filtering.
   kernel, but with a fixed number of neighbours for each spot. This does
   not account for edges, but differences are minimal does not require
   squidpy as a dependency. One can easily replace it on demand. (#
-  <https://github.com/scverse/liana-py/issues/112>)
+  <https://github.com/scverse/liana/issues/112>)
 - Fixed Python version range between 3.8 and 3.12 (Merged #112)
 - Improved the Differential Expression Vignette be more explicit about
   the causal subnetwork search results (related to #66)

--- a/README.md
+++ b/README.md
@@ -1,16 +1,16 @@
-# LIANA+: an all-in-one cell-cell communication framework <img src="https://raw.githubusercontent.com/scverse/liana-py/main/docs/_static/logo.png" align="right" height="125">
+# LIANA+: an all-in-one cell-cell communication framework <img src="https://raw.githubusercontent.com/scverse/liana/main/docs/_static/logo.png" align="right" height="125">
 
 <!-- badges: start -->
-[![main](https://github.com/scverse/liana-py/actions/workflows/test.yml/badge.svg)](https://github.com/scverse/liana-py/actions)
-[![GitHub issues](https://img.shields.io/github/issues/scverse/liana-py.svg)](https://github.com/scverse/liana-py/issues/)
+[![main](https://github.com/scverse/liana/actions/workflows/test.yml/badge.svg)](https://github.com/scverse/liana/actions)
+[![GitHub issues](https://img.shields.io/github/issues/scverse/liana.svg)](https://github.com/scverse/liana/issues/)
 [![Documentation Status](https://readthedocs.org/projects/liana-py/badge/?version=latest)](https://liana-py.readthedocs.io/en/latest/?badge=latest)
-[![codecov](https://codecov.io/gh/scverse/liana-py/graph/badge.svg?token=2HvdhecFQU)](https://codecov.io/gh/scverse/liana-py)
+[![codecov](https://codecov.io/gh/scverse/liana/graph/badge.svg?token=2HvdhecFQU)](https://codecov.io/gh/scverse/liana)
 [![Downloads](https://static.pepy.tech/badge/liana)](https://pepy.tech/project/liana)
 <!-- badges: end -->
 
 LIANA+ is a scalable framework that adapts and extends existing methods and knowledge to study cell-cell communication in single-cell, spatially-resolved, and multi-modal omics data. It is part of the [scverse ecosystem](https://github.com/scverse), and relies on [AnnData](https://github.com/scverse/anndata) & [MuData](https://github.com/scverse/mudata) objects as input.
 
-<img src="https://raw.githubusercontent.com/scverse/liana-py/main/docs/_static/abstract.png" width="700" align="center">
+<img src="https://raw.githubusercontent.com/scverse/liana/main/docs/_static/abstract.png" width="700" align="center">
 
 ## Contributions
 
@@ -22,6 +22,8 @@ A set of extensive vignettes can be found in the [LIANA+ documentation](https://
 ## Decision Tree
 
 Use the tree below to find a starting point for your analysis. Broad, data-driven choices sit at the top and trickle down to specific methods (click a node to open its tutorial).
+
+<!-- decision-tree-start -->
 
 ```mermaid
 flowchart TD
@@ -58,10 +60,10 @@ flowchart TD
     SCMulti --> Metab[Metabolite-mediated CCC]
 
     %% ===== Styling =====
-    classDef decision fill:#f5f5f5,stroke:#37474f,stroke-width:1px,color:#263238;
-    classDef spatial fill:#e3f2fd,stroke:#1565c0,color:#0d47a1;
-    classDef dissoc fill:#e8f5e9,stroke:#2e7d32,color:#1b5e20;
-    classDef multimodal fill:#f3e5f5,stroke:#6a1b9a,color:#4a148c;
+    classDef decision fill:#f6f0f1,stroke:#364159,stroke-width:1px,color:#364159;
+    classDef spatial fill:#e0fbf8,stroke:#00786e,color:#05564f;
+    classDef dissoc fill:#fdeef4,stroke:#ba1b57,color:#7c1039;
+    classDef multimodal fill:#e9ecf3,stroke:#4a587a,color:#2a3348;
     classDef external fill:#ffffff,stroke:#9e9e9e,stroke-dasharray:5 3,color:#424242;
 
     class Start,Res,ScType,SpType,LocalQ,Compare,Contrast,ModalSp decision;
@@ -89,6 +91,8 @@ flowchart TD
     click SCMulti "https://liana-py.readthedocs.io/en/latest/tutorials/notebooks/sc_multi.html"
     click Metab "https://liana-py.readthedocs.io/en/latest/tutorials/notebooks/sc_multi.html#metabolite-mediated-ccc-from-transcriptomics-data"
 ```
+
+<!-- decision-tree-end -->
 
 This tree is a guide rather than an exhaustive map: the methods are modular and can be adapted or combined across data types and questions, and all of them typically build on curated prior knowledge (see the [prior knowledge](https://liana-py.readthedocs.io/en/latest/tutorials/notebooks/prior_knowledge.html) tutorial for working with ligand–receptor and other resources).
 
@@ -129,8 +133,8 @@ Please also consider citing any of the methods and/or resources that were partic
 
 [uv]: https://github.com/astral-sh/uv
 [scverse discourse]: https://discourse.scverse.org/
-[issue tracker]: https://github.com/scverse/liana-py/issues
-[tests]: https://github.com/scverse/liana-py/actions/workflows/test.yml
+[issue tracker]: https://github.com/scverse/liana/issues
+[tests]: https://github.com/scverse/liana/actions/workflows/test.yml
 [documentation]: https://liana-py.readthedocs.io
 [changelog]: https://liana-py.readthedocs.io/en/latest/changelog.html
 [api documentation]: https://liana-py.readthedocs.io/en/latest/api.html

--- a/docs/_static/css/custom.css
+++ b/docs/_static/css/custom.css
@@ -1,14 +1,139 @@
-/* Reduce the font size in data frames - See https://github.com/scverse/cookiecutter-scverse/issues/193 */
-div.cell_output table.dataframe {
-    font-size: 0.8em;
+/* ============================================================================
+   LIANA+ documentation theme.
+   The palette is taken from the logo: navy #364159, turquoise #00FFEA, crimson #BA1B57 and off-white #F6F0F1.
+   Turquoise and crimson are the brand colors, but neither is readable as text on white at full saturation, so darker "ink" variants carry text and the saturated originals stay decorative.
+   The theme (scanpydoc on top of sphinx-book-theme / pydata-sphinx-theme) is steered through its CSS custom properties.
+   ========================================================================= */
+
+/* -- Brand palette --------------------------------------------------------- */
+:root {
+    --liana-navy: #364159;
+    --liana-navy-soft: #4a587a;
+    --liana-crimson: #ba1b57;
+    --liana-crimson-tint: #fdeef4;
+    --liana-crimson-light: #e0577f;
+    --liana-turquoise: #00ffea;
+    --liana-turquoise-ink: #00786e;
+    --liana-turquoise-light: #2fd9c8;
+    --liana-cream: #f6f0f1;
 }
 
-/* Adjust the logo size */
-.logo img {
-    width: 50%; /* or any percentage you want */
-    height: auto; /* maintain aspect ratio */
+/* -- Light mode ------------------------------------------------------------ */
+html[data-theme="light"] {
+    --pst-color-primary: var(--liana-crimson);
+    --pst-color-primary-highlight: var(--liana-navy);
+    --pst-color-secondary: var(--liana-navy);
+    --pst-color-secondary-highlight: var(--liana-navy-soft);
+    --pst-color-link: var(--liana-crimson);
+    --pst-color-link-hover: var(--liana-turquoise-ink);
+    --pst-color-inline-code: var(--liana-turquoise-ink);
+    --pst-color-accent: var(--liana-turquoise);
+    --pst-color-target: var(--liana-crimson-tint);
+
+    --sd-color-primary: var(--liana-crimson);
+    --sd-color-primary-highlight: var(--liana-navy);
+    --sd-color-shadow: rgb(54 65 89 / 18%);
+}
+
+/* -- Dark mode ------------------------------------------------------------- */
+html[data-theme="dark"] {
+    /* The saturated brand colors only have enough contrast on a dark background. */
+    --pst-color-primary: var(--liana-crimson-light);
+    --pst-color-primary-highlight: var(--liana-cream);
+    --pst-color-secondary: var(--liana-turquoise-light);
+    --pst-color-secondary-highlight: var(--liana-cream);
+    --pst-color-link: var(--liana-crimson-light);
+    --pst-color-link-hover: var(--liana-turquoise-light);
+    --pst-color-inline-code: var(--liana-turquoise-light);
+    --pst-color-accent: var(--liana-turquoise);
+    --pst-color-target: rgb(186 27 87 / 28%);
+
+    --sd-color-primary: var(--liana-crimson-light);
+    --sd-color-primary-highlight: var(--liana-turquoise-light);
+    --sd-color-shadow: rgb(0 0 0 / 50%);
+}
+
+/* -- Logo ------------------------------------------------------------------ */
+/* The logo is a hexagon rather than a wordmark, so it needs the height to stay legible. */
+.bd-sidebar-primary .navbar-brand img,
+.bd-sidebar-primary .navbar-brand .logo__image {
+    max-height: 7rem;
+    width: auto;
+    margin: 0 auto;
+}
+
+.bd-header .navbar-brand img,
+.bd-header .navbar-brand .logo__image {
+    max-height: 2.4rem;
+    width: auto;
+}
+
+/* -- Sidebar section captions ---------------------------------------------- */
+.bd-sidebar-primary .caption-text,
+nav.bd-links p.caption .caption-text {
+    color: var(--pst-color-primary);
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    font-size: 0.78rem;
+}
+
+/* Keep the deeply nested API entries compact. */
+li.toctree-l3 {
+    font-size: 81.25% !important;
+}
+
+li.toctree-l4 {
+    font-size: 75% !important;
+}
+
+/* -- Landing page cards (sphinx-design) ------------------------------------ */
+.sd-card {
+    border: 1px solid var(--pst-color-border);
+    border-radius: 0.6rem;
+    transition:
+        transform 0.18s ease,
+        box-shadow 0.18s ease,
+        border-color 0.18s ease;
+}
+
+.sd-card:hover {
+    transform: translateY(-3px);
+    border-color: var(--pst-color-primary);
+    box-shadow: 0 0.5rem 1.25rem var(--sd-color-shadow);
+}
+
+.sd-card .sd-card-title {
+    color: var(--pst-color-secondary);
+    font-weight: 600;
+}
+
+.sd-card .sd-card-title .sd-octicon {
+    color: var(--pst-color-primary);
+    margin-right: 0.4rem;
+    vertical-align: -0.12em;
+}
+
+.sd-card a.sd-card-title,
+.sd-card a.sd-card-title:hover {
+    text-decoration: none;
+}
+
+/* -- Graphical abstract on the landing page -------------------------------- */
+img.liana-hero {
+    display: block;
+    margin: 1.5rem auto 2rem;
+    max-width: 720px;
+    width: 100%;
+    height: auto;
 }
 
 img.no-scaled-link {
     background: transparent !important;
+}
+
+/* -- Reduce the font size in data frames ----------------------------------- */
+/* See https://github.com/scverse/cookiecutter-scverse/issues/193 */
+div.cell_output table.dataframe {
+    font-size: 0.8em;
 }

--- a/docs/about/background.md
+++ b/docs/about/background.md
@@ -1,0 +1,42 @@
+# About LIANA+
+
+LIANA+ scores cell-cell interactions in single-cell, spatially-resolved and multi-modal data.
+The methods it covers were published as separate tools that take different inputs and return different outputs; LIANA+ reimplements them behind one interface, on {class}`~anndata.AnnData` and {class}`~mudata.MuData`.
+If you use it in your work, see {doc}`cite`.
+
+## Design
+
+### One interface, many methods
+
+The methods often disagree, and which one is appropriate depends on the data and the question.
+LIANA+ reimplements the scoring functions of CellPhoneDB, CellChat, Connectome, NATMI, SingleCellSignalR and scSeqComm, along with a log-fold-change score and a geometric mean, so that they take the same input, use the same permutation scheme and return the same table.
+That makes the scores comparable, and {meth}`li.mt.rank_aggregate <liana.mt.rank_aggregate.__call__>` combines them into a rank consensus.
+
+### Methods and prior knowledge are separate
+
+Methods score an interchangeable resource.
+{func}`li.rs.select_resource <liana.rs.select_resource>` returns the curated consensus resource or any of the ligand-receptor databases behind it, {func}`li.rs.translate_resource <liana.rs.translate_resource>` moves a resource across organisms, and {func}`li.rs.get_metalinks <liana.rs.get_metalinks>` replaces the ligands with metabolites.
+A new resource therefore works with every method, and a new method with every resource.
+
+### More than one dissociated dataset
+
+The same scoring machinery covers three further settings.
+In spatially-resolved data, interactions can be restricted to spatial neighborhoods, scored per spot or cell with the bivariate metrics, or modelled as spatial relationships with {class}`li.mt.MistyData <liana.mt.MistyData>` and {meth}`li.mt.lric <liana.mt.lric.__call__>`.
+In multi-modal data, the ligand and the receptor can come from different modalities, such as transcriptome and surface protein, or transcriptome and MALDI-MSI metabolite.
+Across samples or conditions, interaction scores can be reshaped into views and factorized with MOFA or tensor-cell2cell, which summarises a collection of samples as a few communication programs.
+
+### Downstream of the receptor
+
+A ligand-receptor hit on its own says little about the mechanism behind it.
+{func}`li.mt.find_causalnet <liana.mt.find_causalnet>` links the receptors to the transcription factors that respond to them, by solving for the intracellular signaling network that best explains the measured activities.
+
+## Ecosystem
+
+LIANA+ is built on [anndata](https://anndata.readthedocs.io/) and [mudata](https://mudata.readthedocs.io/), and is used together with [scanpy](https://scanpy.readthedocs.io/), [squidpy](https://squidpy.readthedocs.io/), [decoupler](https://decoupler.readthedocs.io/), [omnipath](https://omnipathdb.org/), [MOFA](https://biofam.github.io/MOFA2/), [tensor-cell2cell](https://earmingol.github.io/cell2cell/) and [corneto](https://saezlab.github.io/corneto/).
+The [Saez-Rodriguez group](https://saezlab.org/) develops it, and it is part of the [scverse ecosystem](https://scverse.org/).
+
+## Why LIANA+?
+
+LIANA started in R as a LIgand-receptor ANalysis frAmework that benchmarked and combined the methods and resources that existed at the time.
+The `+` is the Python framework that grew out of it, with the same method-agnostic core extended to spatial, multi-modal, multi-sample and intracellular analyses.
+A liana is also a climbing vine, which is what the logo shows.

--- a/docs/about/cite.md
+++ b/docs/about/cite.md
@@ -1,6 +1,6 @@
 # Citation
 
-If you use LIANA+ in your research, please cite the framework paper, and the 2022 benchmark whenever you use the methods or resources it compared:
+Please cite the framework paper, and the 2022 benchmark if you use the methods or resources it compared:
 
 ```bibtex
 @article{Dimitrov2024,
@@ -30,4 +30,4 @@ If you use LIANA+ in your research, please cite the framework paper, and the 202
 }
 ```
 
-Please also cite the individual methods and resources that were particularly relevant for your research; each method's docstring names its original publication.
+Please also cite the individual methods and resources you relied on. Each method's docstring names its original publication.

--- a/docs/about/cite.md
+++ b/docs/about/cite.md
@@ -1,0 +1,33 @@
+# Citation
+
+If you use LIANA+ in your research, please cite the framework paper, and the 2022 benchmark whenever you use the methods or resources it compared:
+
+```bibtex
+@article{Dimitrov2024,
+    author  = {Dimitrov, Daniel and Sch{\"a}fer, Philipp Sven Lars and Farr, Elias and Rodriguez-Mier, Pablo and Lobentanzer, Sebastian and Badia-i-Mompel, Pau and Dugourd, Aurelien and Tanevski, Jovan and Ramirez Flores, Ricardo Omar and Saez-Rodriguez, Julio},
+    title   = {LIANA+ provides an all-in-one framework for cell--cell communication inference},
+    journal = {Nature Cell Biology},
+    year    = {2024},
+    volume  = {26},
+    number  = {9},
+    pages   = {1613--1622},
+    doi     = {10.1038/s41556-024-01469-w},
+    url     = {https://doi.org/10.1038/s41556-024-01469-w}
+}
+```
+
+```bibtex
+@article{Dimitrov2022,
+    author  = {Dimitrov, Daniel and T{\"u}rei, D{\'e}nes and Garrido-Rodriguez, Martin and Burmedi, Paul L. and Nagai, James S. and Boys, Charlotte and Ramirez Flores, Ricardo O. and Kim, Hyojin and Szalai, Bence and Costa, Ivan G. and Valdeolivas, Alberto and Dugourd, Aur{\'e}lien and Saez-Rodriguez, Julio},
+    title   = {Comparison of methods and resources for cell-cell communication inference from single-cell RNA-Seq data},
+    journal = {Nature Communications},
+    year    = {2022},
+    volume  = {13},
+    number  = {1},
+    pages   = {3224},
+    doi     = {10.1038/s41467-022-30755-0},
+    url     = {https://doi.org/10.1038/s41467-022-30755-0}
+}
+```
+
+Please also cite the individual methods and resources that were particularly relevant for your research; each method's docstring names its original publication.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -43,7 +43,7 @@ needs_sphinx = "4.0"
 html_context = {
     "display_github": True,  # Integrate GitHub
     "github_user": "scverse",
-    "github_repo": "liana-py",
+    "github_repo": "liana",
     "github_version": "main",
     "conf_py_path": "/docs/",
 }
@@ -63,10 +63,10 @@ extensions = [
     "sphinxcontrib.bibtex",
     "sphinxcontrib.katex",
     "sphinx_autodoc_typehints",
-    "scanpydoc.elegant_typehints",
     "sphinx_design",
     "IPython.sphinxext.ipython_console_highlighting",
     "sphinxext.opengraph",
+    "scanpydoc",  # theme + elegant type hints; needs to be before linkcode
     *[p.stem for p in (HERE / "extensions").glob("*.py")],
 ]
 
@@ -139,7 +139,7 @@ exclude_patterns = [
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
 #
-html_theme = "sphinx_book_theme"
+html_theme = "scanpydoc"
 html_static_path = ["_static"]
 html_css_files = ["css/custom.css"]
 
@@ -150,9 +150,14 @@ html_favicon = "_static/logo.png"
 
 html_theme_options = {
     "repository_url": repository_url,
+    "repository_branch": "main",
     "use_repository_button": True,
+    "use_issues_button": True,
     "path_to_docs": "docs/",
     "navigation_with_keys": False,
+    # The crimson of the logo. scanpydoc exposes it as the `--accent-color` CSS variable, which colors the mobile header and the project name.
+    "accent_color": "#ba1b57",
+    "show_toc_level": 2,
 }
 
 pygments_style = "default"

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,16 +1,108 @@
-```{include} ../README.md
+# LIANA+
 
+LIANA+ is an all-in-one framework for cell-cell communication that adapts and extends existing methods and knowledge to single-cell, spatially-resolved, and multi-modal omics data.
+It is part of the [scverse ecosystem](https://scverse.org) and builds on {class}`~anndata.AnnData` and {class}`~mudata.MuData` objects.
+
+```{image} _static/abstract.png
+:alt: Overview of the analyses that LIANA+ supports
+:class: liana-hero
+```
+
+::::{grid} 1 2 2 3
+:gutter: 3
+
+:::{grid-item-card} {octicon}`desktop-download;1.5em;sd-mr-1` Installation
+:link: installation
+:link-type: doc
+
+New to LIANA+? Install it, with or without the optional extras.
+:::
+
+:::{grid-item-card} {octicon}`rocket;1.5em;sd-mr-1` Quickstart
+:link: tutorials/notebooks/basic_usage
+:link-type: doc
+
+Infer ligand-receptor interactions from a single dissociated single-cell dataset.
+:::
+
+:::{grid-item-card} {octicon}`play;1.5em;sd-mr-1` Tutorials
+:link: tutorials
+:link-type: doc
+
+A decision tree and end-to-end vignettes for each type of data and question.
+:::
+
+:::{grid-item-card} {octicon}`code-square;1.5em;sd-mr-1` API reference
+:link: api
+:link-type: doc
+
+A detailed description of every method, resource and plot in the API.
+:::
+
+:::{grid-item-card} {octicon}`comment-discussion;1.5em;sd-mr-1` Discussion
+:link: https://discourse.scverse.org/
+
+Need help? Reach out on the scverse forum to get your questions answered.
+:::
+
+:::{grid-item-card} {octicon}`mark-github;1.5em;sd-mr-1` GitHub
+:link: https://github.com/scverse/liana
+
+Found a bug? Interested in contributing? Check out the source on GitHub.
+:::
+
+::::
+
+## Citation
+
+```{eval-rst}
+.. include:: about/cite.md
+    :start-line: 2
+    :parser: myst
+```
+
+## NumFOCUS
+
+[//]: # "numfocus-fiscal-sponsor-attribution"
+
+LIANA+ is part of the scverse® project ([website](https://scverse.org), [governance](https://scverse.org/about/roles)) and is fiscally sponsored by [NumFOCUS](https://numfocus.org/).
+If you like scverse® and want to support our mission, please consider making a tax-deductible [donation](https://numfocus.org/donate-to-scverse) to help the project pay for developer time, professional services, travel, workshops, and a variety of other needs.
+
+<div align="center">
+<a href="https://numfocus.org/project/scverse">
+  <img
+    src="https://raw.githubusercontent.com/numfocus/templates/master/images/numfocus-logo.png"
+    width="200"
+  >
+</a>
+</div>
+
+```{toctree}
+:caption: General
+:hidden:
+:maxdepth: 1
+
+installation
+api
+contributing
+changelog
+references
 ```
 
 ```{toctree}
-:hidden: true
+:caption: Gallery
+:hidden:
 :maxdepth: 2
 
 tutorials
+```
 
-installation.md
-api.md
-changelog.md
-contributing.md
-references
+```{toctree}
+:caption: About
+:hidden:
+:maxdepth: 1
+
+about/cite
+GitHub <https://github.com/scverse/liana>
+Discourse <https://discourse.scverse.org/>
 ```

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,7 +1,7 @@
 # LIANA+
 
-LIANA+ is an all-in-one framework for cell-cell communication that adapts and extends existing methods and knowledge to single-cell, spatially-resolved, and multi-modal omics data.
-It is part of the [scverse ecosystem](https://scverse.org) and builds on {class}`~anndata.AnnData` and {class}`~mudata.MuData` objects.
+LIANA+ is an all-in-one framework for cell-cell communication.
+It adapts and extends existing methods and prior knowledge to single-cell, spatially-resolved and multi-modal data, on {class}`~anndata.AnnData` and {class}`~mudata.MuData` objects, and is part of the [scverse ecosystem](https://scverse.org).
 
 ```{image} _static/abstract.png
 :alt: Overview of the analyses that LIANA+ supports
@@ -15,40 +15,40 @@ It is part of the [scverse ecosystem](https://scverse.org) and builds on {class}
 :link: installation
 :link-type: doc
 
-New to LIANA+? Install it, with or without the optional extras.
+Install LIANA+ with pip, uv or conda, with or without the optional extras.
 :::
 
 :::{grid-item-card} {octicon}`rocket;1.5em;sd-mr-1` Quickstart
 :link: tutorials/notebooks/basic_usage
 :link-type: doc
 
-Infer ligand-receptor interactions from a single dissociated single-cell dataset.
+Infer ligand-receptor interactions in a dissociated single-cell dataset.
 :::
 
 :::{grid-item-card} {octicon}`play;1.5em;sd-mr-1` Tutorials
 :link: tutorials
 :link-type: doc
 
-A decision tree and end-to-end vignettes for each type of data and question.
+A decision tree, and a runnable notebook for each type of data and question.
 :::
 
 :::{grid-item-card} {octicon}`code-square;1.5em;sd-mr-1` API reference
 :link: api
 :link-type: doc
 
-A detailed description of every method, resource and plot in the API.
+Every method, preprocessing step, resource, dataset and plot.
 :::
 
 :::{grid-item-card} {octicon}`comment-discussion;1.5em;sd-mr-1` Discussion
 :link: https://discourse.scverse.org/
 
-Need help? Reach out on the scverse forum to get your questions answered.
+Ask a question on the scverse forum.
 :::
 
 :::{grid-item-card} {octicon}`mark-github;1.5em;sd-mr-1` GitHub
 :link: https://github.com/scverse/liana
 
-Found a bug? Interested in contributing? Check out the source on GitHub.
+Read the source, report a bug, or open a pull request.
 :::
 
 ::::
@@ -84,8 +84,8 @@ If you like scverse® and want to support our mission, please consider making a 
 
 installation
 api
-contributing
 changelog
+contributing
 references
 ```
 
@@ -102,6 +102,7 @@ tutorials
 :hidden:
 :maxdepth: 1
 
+about/background
 about/cite
 GitHub <https://github.com/scverse/liana>
 Discourse <https://discourse.scverse.org/>

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -30,11 +30,11 @@ conda install bioconda::liana
 
 ::::
 
-This installs the core framework: every ligand-receptor method, the spatial and multi-modal metrics, the prior knowledge resources, and the plots.
+This installs the ligand-receptor methods, the spatial and multi-modal metrics, the prior knowledge resources and the plots.
 
 ## Extras
 
-Some functionality is only needed by part of the user base, and is therefore kept behind the `extras` group:
+Functionality that only part of the user base needs sits behind the `extras` group:
 
 ```bash
 pip install 'liana[extras]'
@@ -42,11 +42,11 @@ pip install 'liana[extras]'
 
 It pulls in [decoupler](https://decoupler.readthedocs.io/), [muon](https://muon.readthedocs.io/), mofax and mofapy2 for multi-view and multi-sample analyses, [omnipath](https://omnipathdb.org/) to query prior knowledge, [pydeseq2](https://pydeseq2.readthedocs.io/) for differential expression, [gseapy](https://gseapy.readthedocs.io/) for enrichment, corneto, cvxpy and PySCIPOpt for the causal network inference, [squidpy](https://squidpy.readthedocs.io/) for the spatial neighborhoods, as well as cell2cell and kneed.
 
-Each of these is imported lazily, so a missing extra only surfaces when you call the function that needs it.
+LIANA+ imports these when they are first used, so a missing one surfaces when you call the function that needs it.
 
 ## Running the tutorials
 
-The tutorials need a few notebook-only packages on top of the extras:
+The notebooks need a few plotting packages on top of the extras:
 
 ```bash
 pip install 'liana[tutorials]'
@@ -66,4 +66,4 @@ cd liana
 uv sync --all-extras
 ```
 
-See the {doc}`contributing guide <contributing>` for how the environments, the test matrix and the docs build are set up.
+The {doc}`contributing guide <contributing>` describes the environments, the test matrix and the docs build.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,48 +1,69 @@
 # Installation
 
-## Basic Installation
+LIANA+ requires Python 3.12 or newer.
 
-Install LIANA using pip:
+::::{tab-set}
+
+:::{tab-item} pip
 
 ```bash
 pip install liana
 ```
 
-## Conda Installation
+:::
+
+:::{tab-item} uv
+
+```bash
+uv add liana
+```
+
+:::
+
+:::{tab-item} conda
 
 ```bash
 conda install bioconda::liana
 ```
 
-## Installation with Extras
+:::
 
-LIANA offers optional dependencies for extended functionality:
+::::
 
-### All Extras
+This installs the core framework: every ligand-receptor method, the spatial and multi-modal metrics, the prior knowledge resources, and the plots.
 
-Install all optional dependencies:
+## Extras
+
+Some functionality is only needed by part of the user base, and is therefore kept behind the `extras` group:
 
 ```bash
 pip install 'liana[extras]'
 ```
 
-This includes additional packages for:
-- Multi-view analysis (decoupler, muon, mofax, mofapy2)
-- Database access (omnipath)
-- Differential expression (pydeseq2)
-- Pathway analysis (gseapy)
-- Optimization (corneto, cvxpy-base, PySCIPOpt)
-- And more (cell2cell, kneed)
+It pulls in [decoupler](https://decoupler.readthedocs.io/), [muon](https://muon.readthedocs.io/), mofax and mofapy2 for multi-view and multi-sample analyses, [omnipath](https://omnipathdb.org/) to query prior knowledge, [pydeseq2](https://pydeseq2.readthedocs.io/) for differential expression, [gseapy](https://gseapy.readthedocs.io/) for enrichment, corneto, cvxpy and PySCIPOpt for the causal network inference, [squidpy](https://squidpy.readthedocs.io/) for the spatial neighborhoods, as well as cell2cell and kneed.
 
-### Development Installation From Source
+Each of these is imported lazily, so a missing extra only surfaces when you call the function that needs it.
+
+## Running the tutorials
+
+The tutorials need a few notebook-only packages on top of the extras:
 
 ```bash
-git clone https://github.com/scverse/liana-py.git
-cd liana-py
-pip install -e '.[dev]'
+pip install 'liana[tutorials]'
 ```
 
-## Requirements
+The two heaviest notebooks (`inflow_mofaflex` and `liana_c2c`) additionally need torch, mofaflex and tensorly:
 
-- Python 3.10 or higher (up to 3.13)
-- Core dependencies: anndata, mudata, scanpy, numba, pandas, and others are installed automatically
+```bash
+pip install 'liana[tutorials-gpu]'
+```
+
+## Development install
+
+```bash
+git clone https://github.com/scverse/liana.git
+cd liana
+uv sync --all-extras
+```
+
+See the {doc}`contributing guide <contributing>` for how the environments, the test matrix and the docs build are set up.

--- a/docs/tutorials.md
+++ b/docs/tutorials.md
@@ -1,20 +1,65 @@
 # Tutorials
 
+Every tutorial is a runnable notebook that starts from a public dataset loaded via {mod}`liana.ds`.
+
+## Which analysis do I need?
+
+Use the tree below to find a starting point.
+Broad, data-driven choices sit at the top and trickle down to specific methods; click a node to open its tutorial.
+
+```{include} ../README.md
+:start-after: <!-- decision-tree-start -->
+:end-before: <!-- decision-tree-end -->
+```
+
+The tree is a guide rather than an exhaustive map: the methods are modular and can be adapted or combined across data types and questions.
+
+## Getting started
+
+The basics of LIANA+: how a method is called, and where the prior knowledge it scores comes from.
+
 ```{toctree}
 :maxdepth: 1
 
 tutorials/notebooks/basic_usage.ipynb
-tutorials/notebooks/sc_multi.ipynb
 tutorials/notebooks/prior_knowledge.ipynb
-tutorials/notebooks/bivariate.ipynb
-tutorials/notebooks/LRIC_tutorial.ipynb
-tutorials/notebooks/sma.ipynb
-tutorials/notebooks/misty.ipynb
+```
+
+## Dissociated single-cell data
+
+Inference within a single sample, and across samples or conditions.
+
+```{toctree}
+:maxdepth: 1
+
 tutorials/notebooks/targeted.ipynb
 tutorials/notebooks/liana_pyCrossTalkeR.ipynb
-tutorials/notebooks/liana_c2c.ipynb
-tutorials/notebooks/mofacellular.ipynb
 tutorials/notebooks/mofatalk.ipynb
+tutorials/notebooks/mofacellular.ipynb
+tutorials/notebooks/liana_c2c.ipynb
+```
+
+## Spatially-resolved data
+
+Interactions that are constrained, scored, or learnt from spatial coordinates.
+
+```{toctree}
+:maxdepth: 1
+
+tutorials/notebooks/bivariate.ipynb
+tutorials/notebooks/misty.ipynb
 tutorials/notebooks/inflow_score.ipynb
 tutorials/notebooks/inflow_mofaflex.ipynb
+tutorials/notebooks/LRIC_tutorial.ipynb
+```
+
+## Multi-modal data
+
+Interactions between modalities, such as transcriptome and surface protein or metabolite.
+
+```{toctree}
+:maxdepth: 1
+
+tutorials/notebooks/sc_multi.ipynb
+tutorials/notebooks/sma.ipynb
 ```

--- a/docs/tutorials.md
+++ b/docs/tutorials.md
@@ -1,22 +1,22 @@
 # Tutorials
 
-Every tutorial is a runnable notebook that starts from a public dataset loaded via {mod}`liana.ds`.
+Each tutorial is a notebook that runs top to bottom on a public dataset from {mod}`liana.ds`.
 
-## Which analysis do I need?
+## Where to start
 
-Use the tree below to find a starting point.
-Broad, data-driven choices sit at the top and trickle down to specific methods; click a node to open its tutorial.
+The tree below goes from the kind of data you have to the methods that apply to it.
+Click a node to open its tutorial.
 
 ```{include} ../README.md
 :start-after: <!-- decision-tree-start -->
 :end-before: <!-- decision-tree-end -->
 ```
 
-The tree is a guide rather than an exhaustive map: the methods are modular and can be adapted or combined across data types and questions.
+The tree is a guide rather than an exhaustive map, since the methods are modular and can be combined across data types and questions.
 
 ## Getting started
 
-The basics of LIANA+: how a method is called, and where the prior knowledge it scores comes from.
+How a method is called, and where the prior knowledge it scores comes from.
 
 ```{toctree}
 :maxdepth: 1
@@ -27,7 +27,7 @@ tutorials/notebooks/prior_knowledge.ipynb
 
 ## Dissociated single-cell data
 
-Inference within a single sample, and across samples or conditions.
+Inference in one sample, and across samples or conditions.
 
 ```{toctree}
 :maxdepth: 1
@@ -41,7 +41,7 @@ tutorials/notebooks/liana_c2c.ipynb
 
 ## Spatially-resolved data
 
-Interactions that are constrained, scored, or learnt from spatial coordinates.
+Interactions restricted to, or modelled from, spatial coordinates.
 
 ```{toctree}
 :maxdepth: 1
@@ -55,7 +55,7 @@ tutorials/notebooks/LRIC_tutorial.ipynb
 
 ## Multi-modal data
 
-Interactions between modalities, such as transcriptome and surface protein or metabolite.
+Interactions between modalities, such as transcriptome and surface protein, or transcriptome and metabolite.
 
 ```{toctree}
 :maxdepth: 1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,8 +83,8 @@ optional-dependencies.tutorials-gpu = [
 ]
 # https://docs.pypi.org/project_metadata/#project-urls
 urls.Documentation = "https://liana.readthedocs.io/"
-urls.Homepage = "https://github.com/scverse/liana-py"
-urls.Source = "https://github.com/scverse/liana-py"
+urls.Homepage = "https://github.com/scverse/liana"
+urls.Source = "https://github.com/scverse/liana"
 
 [dependency-groups]
 dev = [

--- a/src/liana/_core/_common.py
+++ b/src/liana/_core/_common.py
@@ -28,7 +28,6 @@ def _logg(message: str, level: str | None = "info", verbose: bool = False) -> No
         are 'warn' or 'info', any other value will result in no logging.
     verbose
         Controls whether the message is logged or not.
-
     """
     if verbose:
         if level == "warn":
@@ -56,7 +55,6 @@ def _check_if_installed(package_name: str, custom_error_message: str | None = No
     ------
     ImportError
         If the package could not be found/imported.
-
     """
     try:
         imported_module = __import__(package_name)

--- a/src/liana/_core/_docs.py
+++ b/src/liana/_core/_docs.py
@@ -24,7 +24,6 @@ class DocstringProcessor:
     ...     '''Says %(greeting)s.'''
     >>> f.__doc__
     'Says hello.'
-
     """
 
     def __init__(self, **params: str) -> None:
@@ -38,7 +37,6 @@ class DocstringProcessor:
         KeyError
             If the docstring references a placeholder that was never registered.
             (docrep only warned, which let typos survive into the rendered docs.)
-
         """
         if obj.__doc__ is None:
             return obj

--- a/src/liana/_core/_pipe_utils/_aggregate.py
+++ b/src/liana/_core/_pipe_utils/_aggregate.py
@@ -41,7 +41,6 @@ def _aggregate(
     Returns
     -------
     A long pd.DataFrame with ranked LRs
-
     """
     # join the sc to the whole universe between the methods
     if _key_cols is None:
@@ -100,7 +99,6 @@ def _rank_aggregate(
     Returns
     -------
     An array of values /w length of lr_res.shape[0]
-
     """
     assert aggregate_method in ["rra", "mean"]
 
@@ -137,7 +135,6 @@ def _corr_beta_pvals(p: NDArray[np.floating], k: int) -> NDArray[np.floating]:
     Returns
     -------
     An array with corrected p-values
-
     """
     p = np.clip(p * k, a_min=0, a_max=1)
     return p
@@ -164,7 +161,6 @@ def _rho_scores(
     Returns
     -------
     A vector of pvals as implemented in the RRA method
-
     """
     # Sort values by sources (rows)
     rmat = np.sort(rmat, axis=1)
@@ -190,7 +186,6 @@ def _robust_rank_aggregate(rmat: NDArray[np.floating]) -> NDArray[np.floating]:
     Returns
     -------
     An array with p-values for each row
-
     """
     # 0-1 values depending on relative rank of
     # each interaction divided by the max of each method

--- a/src/liana/_core/_pipe_utils/_common.py
+++ b/src/liana/_core/_pipe_utils/_common.py
@@ -37,7 +37,6 @@ def _join_stats(
     Returns
     -------
     Ligand-Receptor stats
-
     """
     source_stats = dedict[source].copy()
     source_stats.columns = source_stats.columns.map(lambda x: "ligand_" + str(x))

--- a/src/liana/_core/_pipe_utils/_get_mean_perms.py
+++ b/src/liana/_core/_pipe_utils/_get_mean_perms.py
@@ -62,7 +62,6 @@ def _get_means_perms(
         - ligand_pos: Index of the ligand in the tensor
         - receptor_pos: Index of the receptor in the perms tensor
         - labels_pos: Index of cell identities in the perms tensor
-
     """
     X = get_x(adata)
     # gating on `isinstance(..., np.float32)` silently skipped a plain `float`
@@ -185,7 +184,6 @@ def _calculate_pvals(
     Returns
     -------
     P-values for the observed scores
-
     """
     # calculate p-values
     if perm_stats is not None:

--- a/src/liana/_core/_pipe_utils/_pre.py
+++ b/src/liana/_core/_pipe_utils/_pre.py
@@ -296,7 +296,7 @@ def _choose_mtx_rep(
 
     Returns
     -------
-        The matrix to be used by liana-py.
+        The matrix to be used by LIANA+.
     """
     if layer is not None and use_raw:
         raise ValueError("Cannot specify `layer` and have `use_raw=True`.")

--- a/src/liana/_core/_pipe_utils/_pre.py
+++ b/src/liana/_core/_pipe_utils/_pre.py
@@ -50,7 +50,6 @@ def assert_covered(
     ------
     ValueError
         When the the number of missing elements in subset (with respect to superset) is over the threshold
-
     """
     subset_arr = np.asarray(subset)
     is_missing = ~np.isin(subset_arr, superset)
@@ -124,7 +123,6 @@ def prep_check_adata(
     Returns
     -------
     Anndata object to be used downstream
-
     """
     X = _choose_mtx_rep(adata=adata, use_raw=use_raw, layer=layer, verbose=verbose)
     old_obsp = dict(adata.obsp)
@@ -221,7 +219,6 @@ def check_vars(var_names: Iterable[str], complex_sep: str | None, verbose: bool 
     complex_sep
         Separator or any substring to check for in the variable names
     %(verbose)s
-
     """
     var_issues = []
     if complex_sep is not None:
@@ -262,7 +259,6 @@ def filter_resource(resource: DataFrame, var_names: Index | NDArray[Any]) -> Dat
     Returns
     -------
     A filtered resource DataFrame
-
     """
     # Remove those without any subunit
     resource = resource[(np.isin(resource.ligand, var_names)) & (np.isin(resource.receptor, var_names))]

--- a/src/liana/datasets/_sample_anndata.py
+++ b/src/liana/datasets/_sample_anndata.py
@@ -25,7 +25,6 @@ def generate_toy_spatial() -> AnnData:
     -------
     `pbmc68k_reduced` with random `obsm['spatial']` coordinates and the spatial
     connectivities that :func:`liana.pp.spatial_neighbors` derives from them.
-
     """
     adata = pbmc68k_reduced()
     adata.X = get_raw_x(adata).copy()  # log-norm expression in .X (scverse convention); .raw kept
@@ -53,7 +52,6 @@ def generate_toy_mdata() -> MuData:
     A MuData object with two views, `'adata_x'` and `'adata_y'`, each with a
     `'scaled'` layer, and with `.obsm['spatial']`,
     `.obsp['spatial_connectivities']`, `.obs` and `.uns` shared at the top level.
-
     """
     import scanpy as sc
     from mudata import MuData
@@ -87,7 +85,6 @@ def generate_toy_adata() -> AnnData:
     -------
     `pbmc68k_reduced` with a randomly-assigned (seeded) `obs['sample']` of four
     samples, and an `obs['case']` splitting those samples into two conditions.
-
     """
     adata = pbmc68k_reduced()
     adata.X = get_raw_x(adata).copy()  # log-norm expression in .X (scverse convention); .raw kept

--- a/src/liana/datasets/_sample_lrs.py
+++ b/src/liana/datasets/_sample_lrs.py
@@ -20,7 +20,6 @@ def sample_lrs(by_sample: bool = False) -> pd.DataFrame:
     A `DataFrame` of `source`/`target` cell types, `ligand_complex`/
     `receptor_complex` pairs, and random `magnitude` and `specificity_rank`
     scores.
-
     """
     row_num = 200
     rng = np.random.default_rng(seed=1)

--- a/src/liana/method/__init__.py
+++ b/src/liana/method/__init__.py
@@ -57,7 +57,6 @@ def show_methods() -> DataFrame:
 
     >>> import liana as li
     >>> methods = li.mt.show_methods()
-
     """
     return _show_methods(_methods + [rank_aggregate, geometric_mean, scseqcomm, cellchat])
 
@@ -78,7 +77,6 @@ def get_method_scores() -> dict[str, bool | None]:
 
     >>> import liana as li
     >>> scores = li.mt.get_method_scores()
-
     """
     alive = [ref() for ref in _MethodMeta.instances]
     instances = [instance for instance in alive if isinstance(instance, _Method | AggregateClass)]
@@ -119,7 +117,6 @@ def process_scores(liana_res: DataFrame, score_key: str, inverse_fn: ScoreTransf
     >>> adata = li.ds.generate_toy_adata()
     >>> li.mt.rank_aggregate(adata, groupby="bulk_labels", n_perms=None)
     >>> res = li.mt.process_scores(adata.uns["liana_res"], score_key="magnitude_rank")
-
     """
     df = liana_res.copy()
     scores = get_method_scores()

--- a/src/liana/method/df_to_lr.py
+++ b/src/liana/method/df_to_lr.py
@@ -98,7 +98,6 @@ def df_to_lr(
     Each statistic named in `stat_keys` is carried over to both sides of every
     interaction -- as `ligand_stat` and `receptor_stat` -- and averaged into an
     `interaction_stat` column.
-
     """
     _check_groupby(adata=adata, groupby=groupby, verbose=verbose)
     if (groupby not in adata.obs.columns) or (groupby not in dea_df.columns):

--- a/src/liana/method/fun/_causalnet.py
+++ b/src/liana/method/fun/_causalnet.py
@@ -99,7 +99,6 @@ def find_causalnet(
     >>> df, problem = li.mt.find_causalnet(
     ...     prior, input_node_scores={"CD4": 1.0}, output_node_scores={"JUN": 1.0, "FOS": -1.0}, verbose=False
     ... )
-
     """
     cn = _check_if_installed("corneto")
 

--- a/src/liana/method/fun/_estimate_metalinks.py
+++ b/src/liana/method/fun/_estimate_metalinks.py
@@ -72,7 +72,6 @@ def estimate_metalinks(
     the membrane on their own. The result is the input to
     ``liana.mt.bivariate`` or to any single-cell method, with
     `x_mod='metabolite'` and `y_mod='receptor'`.
-
     """
     dc = _check_if_installed(package_name="decoupler")
     ad = prep_check_adata(

--- a/src/liana/method/sc/_Method.py
+++ b/src/liana/method/sc/_Method.py
@@ -80,7 +80,6 @@ class MethodMeta:
         Publication reference in Harvard style
     instances
         List of instances of this class
-
     """
 
     # Weak references, so a method instance is not kept alive by this registry.
@@ -169,7 +168,6 @@ class MethodMeta:
         -------
         A pandas DataFrame with the results and a column sample is stored in `adata.uns[key_added]` if `inplace` is True,
         else the DataFrame is returned.
-
         """
         obs = get_obs(adata)
         if sample_key not in obs:
@@ -221,7 +219,6 @@ class Method(MethodMeta):
     ----------
     method
         Instance of metod metadata class
-
     """
 
     def __init__(self, _method: MethodMeta):
@@ -313,7 +310,6 @@ class Method(MethodMeta):
         >>> import liana as li
         >>> adata = li.ds.generate_toy_adata()
         >>> li.mt.cellphonedb(adata, groupby="bulk_labels", n_perms=100)
-
         """
         if supp_columns is None:
             supp_columns = []

--- a/src/liana/method/sc/_cellchat.py
+++ b/src/liana/method/sc/_cellchat.py
@@ -37,7 +37,6 @@ def _cellchat_score(
     Returns
     -------
     A tuple with lr_mean and pvalue for x
-
     """
     lr_prob = _lr_probability((x["ligand_trimean"].to_numpy(), x["receptor_trimean"].to_numpy()))
     lr_prob, proximity_weights = _apply_proximity_weights(lr_prob, x)

--- a/src/liana/method/sc/_cellphonedb.py
+++ b/src/liana/method/sc/_cellphonedb.py
@@ -31,7 +31,6 @@ def _cpdb_score(
     Returns
     -------
     A tuple with lr_mean and p-value for x
-
     """
     zero_msk = (x["ligand_means"] == 0) | (x["receptor_means"] == 0)
     lr_means = _mean((x["ligand_means"].to_numpy(), x["receptor_means"].to_numpy()))

--- a/src/liana/method/sc/_connectome.py
+++ b/src/liana/method/sc/_connectome.py
@@ -18,7 +18,6 @@ def _connectome_score(x: DataFrame) -> tuple[NDArray[np.floating], NDArray[np.fl
     Returns
     -------
     tuple(expr_prod, scaled_weight)
-
     """
     # magnitude
     expr_prod = x["ligand_means"].to_numpy() * x["receptor_means"].to_numpy()

--- a/src/liana/method/sc/_geometric_mean.py
+++ b/src/liana/method/sc/_geometric_mean.py
@@ -24,7 +24,6 @@ def _gmean_score(
     Returns
     -------
     A tuple with lr_mean and p-value for x
-
     """
     lr_gmeans = np.asarray(gmean((x["ligand_means"].to_numpy(), x["receptor_means"].to_numpy()), axis=0))
     weighted, proximity_weights = _apply_proximity_weights(lr_gmeans, x)

--- a/src/liana/method/sc/_liana_pipe.py
+++ b/src/liana/method/sc/_liana_pipe.py
@@ -125,7 +125,6 @@ def liana_pipe(
     Returns
     -------
     A DataFrame with ligand-receptor results
-
     """
     if mdata_kwargs is None:
         mdata_kwargs = MdataKwargs()

--- a/src/liana/method/sc/_rank_aggregate.py
+++ b/src/liana/method/sc/_rank_aggregate.py
@@ -39,7 +39,6 @@ class AggregateClass(MethodMeta):
         Additional columns required for each method
     complex_cols
         Columns relevant for protein complexes for each method
-
     """
 
     def __init__(self, _SCORE: MethodMeta, methods: list[Method]) -> None:
@@ -164,7 +163,6 @@ class AggregateClass(MethodMeta):
         >>> li.mt.rank_aggregate(adata, groupby="bulk_labels", n_perms=None)
 
         The frame carries `magnitude_rank` and `specificity_rank` alongside each aggregated method's own scores -- ``li.mt.rank_aggregate.describe()`` says what the ranks mean, and ``liana.mt.rank_aggregate`` which methods go into them.
-
         """
         if mdata_kwargs is None:
             mdata_kwargs = {}

--- a/src/liana/method/sc/_scseqcomm.py
+++ b/src/liana/method/sc/_scseqcomm.py
@@ -18,7 +18,6 @@ def _inter_score(x: DataFrame) -> tuple[Series, None]:
     inter_score
         Pair-wise minimum CDF
     None
-
     """
     inter_score = np.minimum(x["ligand_cdf"], x["receptor_cdf"])
     return Series(inter_score, index=x.index), None

--- a/src/liana/method/sc/_singlecellsignalr.py
+++ b/src/liana/method/sc/_singlecellsignalr.py
@@ -18,7 +18,6 @@ def _sca_score(x: DataFrame) -> tuple[Series, None]:
     LRscore
         The ligand-receptor scores
     None
-
     """
     lr_sqrt = np.sqrt(x["ligand_means"]) * np.sqrt(x["receptor_means"])
     denominator = lr_sqrt + x.mat_mean

--- a/src/liana/method/sp/_LRIC.py
+++ b/src/liana/method/sp/_LRIC.py
@@ -565,7 +565,6 @@ class LRIC:
 
     LRIC builds on the cross pair-correlation function; see
     (:class:`CrossPCF`).
-
     """
 
     @d.dedent
@@ -789,7 +788,6 @@ class LRIC:
         actual self-pairs are excluded from the edge set. Reduces exactly to
         ``CrossPCF``'s directed curve when weights are one-hot type
         indicators.
-
         """
         _logg("Running cell-type-agnostic LRIC.", verbose=verbose)
 

--- a/src/liana/method/sp/_bivariate/_global_functions.py
+++ b/src/liana/method/sp/_bivariate/_global_functions.py
@@ -138,7 +138,6 @@ class GlobalFunction:
         ------
         ValueError
             If the given function is not supported
-
         """
         norm_weight: Weight
         x_dense: np.ndarray

--- a/src/liana/method/sp/_bivariate/_local_functions.py
+++ b/src/liana/method/sp/_bivariate/_local_functions.py
@@ -52,7 +52,6 @@ class LocalFunction:
         The actual function
     reference
         Reference/description for the function
-
     """
 
     instances: dict[str, LocalFunction] = {}
@@ -103,7 +102,6 @@ class LocalFunction:
             Matrix with the local scores
         local_pvals
             Matrix of resulting p-values
-
         """
         norm_weight: Weight = weight
         x_dense: np.ndarray
@@ -205,7 +203,6 @@ class LocalFunction:
         Returns
         -------
         2D array of p-values with shape(n_spot, xy_n)
-
         """
         spot_n = x_mat.shape[0]
 
@@ -252,7 +249,6 @@ class LocalFunction:
         Returns
         -------
         2D array of standard deviations with shape(n_spot, xy_n)
-
         """
         dense = weight if isinstance(weight, np.ndarray) else np.asarray(weight.todense())
 
@@ -339,7 +335,6 @@ def _vectorized_correlations(
     Vectorized implementation of weighted correlations.
 
     Note: due to the imprecision of np.sum and np.dot, the function is accurate to 5 decimal places.
-
     """
     if method not in ["pearson", "spearman"]:
         raise ValueError("method must be one of 'pearson', 'spearman'")
@@ -416,7 +411,6 @@ def _local_morans(x_mat: np.ndarray, y_mat: np.ndarray, weight: Weight) -> np.nd
     Returns
     -------
     Returns 2D array of local Moran's I with shape(n_spot, xy_n)
-
     """
     local_x = x_mat * (weight @ y_mat)
     local_y = y_mat * (weight @ x_mat)

--- a/src/liana/method/sp/_bivariate/_spatial_bivariate.py
+++ b/src/liana/method/sp/_bivariate/_spatial_bivariate.py
@@ -43,7 +43,6 @@ class SpatialBivariate:
     ----------
     %(x_name)s
     %(y_name)s
-
     """
 
     @d.dedent
@@ -163,7 +162,6 @@ class SpatialBivariate:
         ``li.mt.bivariate.show_functions()`` lists the available `local_name` choices.
         Pass a `MuData` with `x_mod`/`y_mod` instead of an `AnnData` to relate two
         modalities.
-
         """
         if n_perms is not None and n_perms < 0:
             raise ValueError("n_perms must be None, 0 for analytical or > 0 for permutation")
@@ -324,7 +322,6 @@ class SpatialBivariate:
         Returns
         -------
         Table of the bivariate methods and their description.
-
         """
         funs = {
             function.name: {

--- a/src/liana/method/sp/_compute_global_specificity.py
+++ b/src/liana/method/sp/_compute_global_specificity.py
@@ -85,7 +85,6 @@ def compute_global_specificity(
     more permutations than the 10 here -- the smallest attainable p-value is
     `1/(n_perms+1)`. `n_jobs=1` avoids the process-spawn overhead that the default `-1`
     costs at this size.
-
     """
     if groupby not in adata.obs.columns:
         raise KeyError(f"`groupby`='{groupby}' not found in adata.obs.")

--- a/src/liana/method/sp/_inflow.py
+++ b/src/liana/method/sp/_inflow.py
@@ -153,7 +153,6 @@ class SpatialInflow:
         `'CD4+/CD25 T Reg^HLA-DRA^CD4'`. Cell-type proportions per spot can be given
         via `obsm_key` instead of `groupby`, which is what deconvolved spot data calls
         for.
-
         """
         # Process MuData or AnnData - check instance and process accordingly
         _check_instance(adata)  # raises for anything other than AnnData/MuData

--- a/src/liana/method/sp/_misty/_Misty.py
+++ b/src/liana/method/sp/_misty/_Misty.py
@@ -74,7 +74,6 @@ class MistyData(MuData):
     :func:`liana.mt.lrMistyData` build the views for the two most common
     designs. Call the object to fit the model -- see
     :func:`liana.mt.MistyData.__call__`.
-
     """
 
     def __init__(
@@ -159,7 +158,6 @@ class MistyData(MuData):
         Returns
         -------
         Weighted matrix of the requested view and predictors. If no predictors are provided, returns the variable names.
-
         """
         view = self._view(view_name)
         selected = view.var_names if predictors is None else predictors
@@ -233,7 +231,6 @@ class MistyData(MuData):
         >>> adata = adata[:, adata.var_names[:5]].copy()
         >>> misty = li.mt.genericMistyData(intra=adata, bandwidth=200, set_diag=True)
         >>> misty(model=li.mt.sp.LinearModel)
-
         """
         fitted_model = model(seed, **kwargs)
         view_str = list(self.view_names)

--- a/src/liana/method/sp/_misty/_misty_constructs.py
+++ b/src/liana/method/sp/_misty/_misty_constructs.py
@@ -128,7 +128,6 @@ def genericMistyData(
     Pass a second object as `extra` to predict the intra view from a different
     modality (e.g. cell-type composition, or pathway activities). Then call the
     object to fit the model -- see :func:`liana.mt.MistyData.__call__`.
-
     """
     # init views
     views = {}
@@ -263,7 +262,6 @@ def lrMistyData(
 
     Fitting this asks, per receptor, which neighbouring ligands predict it -- call the object with ``bypass_intra=True`` so that the receptors are not predicted from each other.
     See :func:`liana.mt.MistyData.__call__`.
-
     """
     # TODO: reduce redundancies in documentation
     if resource is None:

--- a/src/liana/method/sp/_misty/_single_view_models.py
+++ b/src/liana/method/sp/_misty/_single_view_models.py
@@ -41,7 +41,6 @@ class SingleViewModel:
         Contains the resulting predictions in array form.
     importances : dict[str, float]
         Contains the importance scores of the different predictors.
-
     """
 
     def __init__(self, seed: int, **kwargs: Any) -> None:
@@ -94,7 +93,6 @@ class SingleViewModel:
         Returns
         -------
         Matrix with the prediction results for each round of CV
-
         """
         predictions = np.zeros_like(y)
         kf = KFold(n_splits=k_cv, random_state=self.seed, shuffle=True)
@@ -124,7 +122,6 @@ class RandomForestModel(SingleViewModel):
             List of feature names
         k_cv
             Not used
-
         """
         forest = RandomForestRegressor(oob_score=True, random_state=self.seed, **self.kwargs)
         forest.fit(X, y)
@@ -150,7 +147,6 @@ class LinearModel(SingleViewModel):
             List of feature names
         k_cv
             Number of cross-validation folds. If None, no cross-validation is performed.
-
         """
         # NOTE: read, don't pop -- `fit` is called once per target on the same
         # instance, so popping would apply `n_jobs` to the first target only.
@@ -188,7 +184,6 @@ class RobustLinearModel(SingleViewModel):
             List of feature names
         k_cv
             Number of cross-validation folds. If None, no cross-validation is performed.
-
         """
         if k_cv is None:
             raise ValueError("`k_cv` must be provided for the robust linear model.")

--- a/src/liana/multisample/_getters.py
+++ b/src/liana/multisample/_getters.py
@@ -47,7 +47,6 @@ def get_factor_scores(
 
     `scores` has one `Factor{i}` column per factor, an `index` column of the original
     barcodes, and any `.obs` columns named in `obs_keys`.
-
     """
     if obsm_key is None or obsm_key not in adata.obsm.keys():
         raise ValueError(f"{obsm_key} not found in `.obsm`")
@@ -139,7 +138,6 @@ def get_variable_loadings(
     Views built by :func:`liana.ms.lrs_to_views` name their variables
     `'source&target:ligand^receptor'`, which `view_sep=':'`, `variable_sep='^'` and
     `pair_sep='&'` split in the same way.
-
     """
     if var_names is None:
         var_names = ["ligand_complex", "receptor_complex"]

--- a/src/liana/multisample/_nmf.py
+++ b/src/liana/multisample/_nmf.py
@@ -72,7 +72,6 @@ def nmf(
 
     Read the factors out with :func:`liana.ms.get_factor_scores` and
     :func:`liana.ms.get_variable_loadings`.
-
     """
     X: MatrixLike
     if adata is not None:
@@ -148,7 +147,6 @@ def estimate_elbow(
     If no knee can be located within `k_range`, `rank` comes back as `None` --
     widen the range. A `k_range` that starts above the true rank returns its own
     lowest value.
-
     """
     kn = _check_if_installed("kneed")
     error_values = [_calculate_error(X, k, **kwargs) for k in tqdm(k_range, disable=not verbose)]

--- a/src/liana/multisample/mdata_to_anndata.py
+++ b/src/liana/multisample/mdata_to_anndata.py
@@ -71,7 +71,6 @@ def mdata_to_anndata(
     >>> import liana as li
     >>> mdata = li.ds.generate_toy_mdata()
     >>> adata = li.ms.mdata_to_anndata(mdata, x_mod="adata_x", y_mod="adata_y", x_layer="scaled", y_layer="scaled")
-
     """
     xdata = _handle_mod(mdata, x_mod, x_use_raw, x_layer, x_transform, verbose)
     ydata = _handle_mod(mdata, y_mod, y_use_raw, y_layer, y_transform, verbose)

--- a/src/liana/multisample/to_mudata.py
+++ b/src/liana/multisample/to_mudata.py
@@ -78,7 +78,6 @@ def adata_to_views(
     prefixed with its view, and `obs_keys` are joined onto the sample-level `.obs`.
     Pass `filter_by_expr_kwargs` to tighten or relax those filters -- they go
     straight to `decoupler`.
-
     """
     # Check if MuData & decoupler are installed
     if filter_by_prop_kwargs is None:
@@ -245,7 +244,6 @@ def lrs_to_views(
     interactions by sample. The thresholds are relaxed below their defaults here
     only because the toy scores are random and no view would otherwise survive
     them -- on real data the defaults are the sensible starting point.
-
     """
     if (sample_key not in adata.obs.columns) or (sample_key not in adata.uns[uns_key].columns):
         raise ValueError(
@@ -395,7 +393,6 @@ def lrdata_to_mudata(
 
     The sender in each `'sender^ligand^receptor'` name becomes one modality, so that
     every sender cell type can be modelled as its own view.
-
     """
     if not isinstance(lrdata, AnnData):
         raise TypeError("`lrdata` must be an AnnData object.")
@@ -575,7 +572,6 @@ def filter_view_markers(
 
     Pass `var_column='highly_variable'` instead to only flag them, and
     `inplace=True` to modify `mdata` rather than return a copy.
-
     """
     # check if markers is a dict
     if not isinstance(markers, dict):

--- a/src/liana/multisample/to_tensor_c2c.py
+++ b/src/liana/multisample/to_tensor_c2c.py
@@ -82,7 +82,6 @@ def to_tensor_c2c(
     >>> tensor = li.ms.to_tensor_c2c(adata, sample_key="sample", score_key="specificity_rank")
 
     The tensor can then be decomposed with Tensor-cell2cell.
-
     """
     # check if cell2cell is installed
     c2c = _check_if_installed("cell2cell")

--- a/src/liana/plotting/_annulus.py
+++ b/src/liana/plotting/_annulus.py
@@ -61,7 +61,6 @@ def annulus_plot(
     >>> import liana as li
     >>> adata = li.ds.generate_toy_spatial()
     >>> li.pl.annulus_plot(adata, radius_step=200, n_rings=4)
-
     """
     if spatial_key not in adata.obsm:
         raise KeyError(f"'{spatial_key}' not found in adata.obsm.")

--- a/src/liana/plotting/_circle_plot.py
+++ b/src/liana/plotting/_circle_plot.py
@@ -113,7 +113,6 @@ def get_mask_df(
     Returns
     -------
     The resulting masked table
-
     """
     if source_cell_type is None and target_cell_type is None:
         return pivot_table
@@ -241,7 +240,6 @@ def circle_plot(
 
     With `pivot_mode='mean'` and a `score_key` the edges are weighted by that
     score's mean instead of by the number of interactions.
-
     """
     if groupby is None:
         raise ValueError("`groupby` must be provided!")

--- a/src/liana/plotting/_connectivity_plot.py
+++ b/src/liana/plotting/_connectivity_plot.py
@@ -54,7 +54,6 @@ def connectivity(
     >>> import liana as li
     >>> adata = li.ds.generate_toy_spatial()
     >>> p = li.pl.connectivity(adata, idx=0)
-
     """
     assert connectivity_key in list(adata.obsp.keys())
     assert spatial_key in adata.obsm_keys()

--- a/src/liana/plotting/_dotplot.py
+++ b/src/liana/plotting/_dotplot.py
@@ -92,7 +92,6 @@ def dotplot(
     ...     orderby="magnitude_rank",
     ...     orderby_ascending=True,
     ... )
-
     """
     liana_res = _prep_liana_res(
         adata=adata,
@@ -203,7 +202,6 @@ def dotplot_by_sample(
     >>> adata = li.ds.generate_toy_adata()
     >>> li.mt.rank_aggregate.by_sample(adata, sample_key="sample", groupby="bulk_labels", n_perms=None)
     >>> p = li.pl.dotplot_by_sample(adata, colour="lr_means", size="magnitude_rank", ligand_complex="HLA-DRA")
-
     """
     liana_res = _prep_liana_res(
         adata=adata,

--- a/src/liana/plotting/_feature_by_group.py
+++ b/src/liana/plotting/_feature_by_group.py
@@ -75,7 +75,6 @@ def feature_by_group(
     >>> fig, ax = li.pl.feature_by_group(
     ...     lrdata, groupby="bulk_labels", labels=["Dendritic", "CD14+ Monocyte"], feature=lrdata.var_names[0]
     ... )
-
     """
     # Validate inputs
     if adata is None:

--- a/src/liana/plotting/_misty_plots.py
+++ b/src/liana/plotting/_misty_plots.py
@@ -66,7 +66,6 @@ def target_metrics(
 
     Pass `aggregate_fn` (e.g. `numpy.mean`) to summarise a masked model's
     per-group rows into boxplots.
-
     """
     if target_metrics is not None:
         target_metrics = target_metrics.copy()
@@ -149,7 +148,6 @@ def contributions(
     >>> misty = li.mt.genericMistyData(intra=adata, bandwidth=200, set_diag=True)
     >>> misty(model=li.mt.sp.LinearModel)
     >>> p = li.pl.contributions(misty)
-
     """
     if target_metrics is not None:
         target_metrics = target_metrics.copy()
@@ -248,7 +246,6 @@ def interactions(
 
     `misty.view_names` lists the views available -- here `'intra'`, `'juxta'` and
     `'para'`.
-
     """
     if interactions is not None:
         interactions = interactions.copy()

--- a/src/liana/plotting/_tileplot.py
+++ b/src/liana/plotting/_tileplot.py
@@ -83,7 +83,6 @@ def tileplot(
     >>> adata = li.ds.generate_toy_adata()
     >>> li.mt.cellphonedb(adata, groupby="bulk_labels", n_perms=100)
     >>> p = li.pl.tileplot(adata, fill="means", label="props", top_n=10, orderby="lr_means")
-
     """
     liana_res = _prep_liana_res(
         adata=adata,

--- a/src/liana/preprocessing/expand_coordinates.py
+++ b/src/liana/preprocessing/expand_coordinates.py
@@ -50,7 +50,6 @@ def expand_coordinates(
     >>> rng = np.random.default_rng(0)
     >>> adata.obs["sample"] = rng.choice(["A", "B", "C", "D"], size=adata.n_obs)
     >>> expanded = li.pp.expand_coordinates(adata, sample_key="sample")
-
     """
     if sample_key not in get_obs(adata):
         raise ValueError(f"`sample_key` '{sample_key}' was not found in `adata.obs`.")

--- a/src/liana/preprocessing/interpolate_adata.py
+++ b/src/liana/preprocessing/interpolate_adata.py
@@ -57,7 +57,6 @@ def interpolate_adata(
     >>> target = li.ds.generate_toy_spatial()
     >>> reference = target[::2].copy()
     >>> interpolated = li.pp.interpolate_adata(target=target, reference=reference, spatial_key="spatial")
-
     """
     target_coords = target.obsm[spatial_key]
     reference_coords = reference.obsm[spatial_key]

--- a/src/liana/preprocessing/obsm_to_adata.py
+++ b/src/liana/preprocessing/obsm_to_adata.py
@@ -53,7 +53,6 @@ def obsm_to_adata(
     >>> import liana as li
     >>> adata = li.ds.generate_toy_adata()
     >>> pca = li.pp.obsm_to_adata(adata, "X_pca")
-
     """
     if df is None:
         entry = adata.obsm[obsm_key]

--- a/src/liana/preprocessing/query_bandwidth.py
+++ b/src/liana/preprocessing/query_bandwidth.py
@@ -48,7 +48,6 @@ def query_bandwidth(
     >>> import liana as li
     >>> adata = li.ds.generate_toy_spatial()
     >>> fig, df = li.pp.query_bandwidth(adata.obsm["spatial"], start=0, end=1000)
-
     """
     tree = BallTree(coordinates, metric="euclidean")
     df = DataFrame()

--- a/src/liana/preprocessing/spatial_neighbors.py
+++ b/src/liana/preprocessing/spatial_neighbors.py
@@ -145,7 +145,6 @@ def spatial_neighbors(
     `bandwidth` is required and sets the distance over which proximity decays --
     :func:`liana.pp.query_bandwidth` helps pick it -- while `kernel` sets the shape
     of that decay.
-
     """
     if cutoff is None:
         raise ValueError("`cutoff` must be provided!")
@@ -269,7 +268,6 @@ def spatial_pair_proximity(
     0  CD14+ Monocyte  CD14+ Monocyte      0.663
     1  CD14+ Monocyte         CD19+ B      0.628
     2  CD14+ Monocyte           CD34+      0.020
-
     """
     # groupby_labels use categories if categorical
     groupby_labels = np.asarray(get_obs(adata)[groupby])

--- a/src/liana/preprocessing/transform.py
+++ b/src/liana/preprocessing/transform.py
@@ -46,7 +46,6 @@ def zi_minmax(X: MatrixLike, cutoff: float = 0.5) -> csr_matrix:
     array([[0.   , 0.   ],
            [0.352, 0.544],
            [1.   , 1.   ]])
-
     """
     copied = X.copy()
     mat = copied if isspmatrix_csr(copied) else csr_matrix(copied)
@@ -90,7 +89,6 @@ def neg_to_zero(X: MatrixLike, cutoff: float = 0) -> csr_matrix:
 
     >>> li.pp.neg_to_zero(x, cutoff=0.5).toarray()
     array([[0., 0., 0., 0., 2.]])
-
     """
     copied = X.copy()
     mat = copied if isspmatrix_csr(copied) else csr_matrix(copied)

--- a/src/liana/resource/_orthology.py
+++ b/src/liana/resource/_orthology.py
@@ -129,7 +129,6 @@ def translate_column(
     With `replace=False` the translation is added as an `orthology_ligand` column
     instead of overwriting `ligand`. Use
     :func:`liana.rs.translate_resource` to do both sides at once.
-
     """
     if not isinstance(one_to_many, int):
         raise ValueError("`one_to_many` should be a positive integer!")
@@ -202,7 +201,6 @@ def translate_resource(
     0  Lgals9    Ptprc
     1  Lgals9      Met
     2  Lgals9     Cd44
-
     """
     if columns is None:
         columns = ["ligand", "receptor"]
@@ -270,7 +268,6 @@ def get_hcop_orthologs(
             columns=["human_symbol", "mouse_symbol"],
             min_evidence=3,
         ).rename(columns={"human_symbol": "source", "mouse_symbol": "target"})
-
     """
     if url is None:
         url = f"{_HCOP_BASE}/human_{target_organism}_hcop_fifteen_column.txt.gz"

--- a/src/liana/resource/_prior_network.py
+++ b/src/liana/resource/_prior_network.py
@@ -59,7 +59,6 @@ def build_prior_network(
 
     The network is pruned to what lies on a path from an input to an output. Hand
     the result to :func:`liana.mt.find_causalnet`.
-
     """
     _check_if_installed("corneto")  # raises a helpful ImportError if the extra is missing
     from corneto import Graph

--- a/src/liana/resource/_reassemble_complexes.py
+++ b/src/liana/resource/_reassemble_complexes.py
@@ -37,7 +37,6 @@ def _filter_reassemble_complexes(
     Return
     -----------
     lr_res: a reduced long-format pandas dataframe
-
     """
     # Filter by expr_prop (inner join only complexes where all subunits are expressed)
     expressed = (
@@ -134,7 +133,6 @@ def _explode_complexes(resource: pd.DataFrame, SOURCE: str = "ligand", TARGET: s
     Returns
     -------
     A resource with exploded complexes
-
     """
     resource["interaction"] = resource[SOURCE] + "&" + resource[TARGET]
     resource = (

--- a/src/liana/resource/_resource_utils.py
+++ b/src/liana/resource/_resource_utils.py
@@ -75,7 +75,6 @@ def generate_lr_geneset(
 
     The result can then be handed to an enrichment method
     (e.g. `decoupler`) with the interaction names as features.
-
     """
     # TODO: Fix this if else, it's not very elegant
     if weight is None:

--- a/src/liana/resource/get_metalinks.py
+++ b/src/liana/resource/get_metalinks.py
@@ -15,7 +15,6 @@ def _download_metalinksdb(verbose: bool = True) -> str:
     Returns
     -------
     The path to the downloaded database file.
-
     """
     requests = _check_if_installed("requests")
 
@@ -123,7 +122,6 @@ def get_metalinks(
             types=["lr"],
             biospecimen_location="Blood",
         )
-
     """
     if db_path is None:
         db_path = _download_metalinksdb()
@@ -219,7 +217,6 @@ def get_metalinks_values(table_name: str, column_name: str, db_path: str | None 
     :func:`liana.rs.get_metalinks`::
 
         get_metalinks_values(table_name="tissue_location", column_name="tissue_location")
-
     """
     if db_path is None:
         db_path = _download_metalinksdb()
@@ -255,7 +252,6 @@ def describe_metalinks(db_path: str | None = None, return_output: bool = False) 
     It prints the tables and columns that :func:`liana.rs.get_metalinks` and :func:`liana.rs.get_metalinks_values` query::
 
         describe_metalinks()
-
     """
     if db_path is None:
         db_path = _download_metalinksdb()

--- a/src/liana/resource/get_metalinks.py
+++ b/src/liana/resource/get_metalinks.py
@@ -20,7 +20,7 @@ def _download_metalinksdb(verbose: bool = True) -> str:
     requests = _check_if_installed("requests")
 
     # GitHub Releases URL (CI-friendly, no WAF issues)
-    METALINKS_URL = "https://github.com/scverse/liana-py/releases/download/metalinksdb/metalinksdb.db"
+    METALINKS_URL = "https://github.com/scverse/liana/releases/download/metalinksdb/metalinksdb.db"
 
     db_file_name = "metalinksdb.db"
     db_path = os.path.join(os.getcwd(), db_file_name)

--- a/src/liana/resource/select_resource.py
+++ b/src/liana/resource/select_resource.py
@@ -40,7 +40,6 @@ def select_resource(resource_name: str = V.resource_name) -> DataFrame:
     2  LGALS9     CD44
 
     Pass the frame to any method via `resource=`.
-
     """
     resource_name = resource_name.lower()
 
@@ -74,7 +73,6 @@ def show_resources() -> list[str]:
 
     >>> import liana as li
     >>> resources = li.rs.show_resources()
-
     """
     resource_path = pathlib.Path(__file__).parent.joinpath("omni_resource.csv")
     resource = read_csv(resource_path, index_col=False)

--- a/tests/method/sp/test_misty.py
+++ b/tests/method/sp/test_misty.py
@@ -132,7 +132,7 @@ def test_misty_mask(adata: AnnData) -> None:
 
 
 def test_misty_uns_preserved_on_reconstruction(adata: AnnData) -> None:
-    # https://github.com/scverse/liana-py/issues/242
+    # https://github.com/scverse/liana/issues/242
     # reconstructing a MistyData from an existing (Misty/Mu)Data must not drop `uns`
     misty = genericMistyData(adata, bandwidth=10, set_diag=False, cutoff=0)
     misty(model=LinearModel)

--- a/tests/resource/test_select_resource.py
+++ b/tests/resource/test_select_resource.py
@@ -51,7 +51,7 @@ def test_select_resource_name() -> None:
 
 
 def test_consensus_pecam1_cd38_direction() -> None:
-    # https://github.com/scverse/liana-py/issues/218
+    # https://github.com/scverse/liana/issues/218
     # The PECAM1-CD38 interaction is directed PECAM1 (ligand) -> CD38 (receptor),
     # as in CellPhoneDB and the literature (PMID: 7542249). The consensus row was
     # flipped (CD38 -> PECAM1); assert the corrected direction is the only one.
@@ -61,7 +61,7 @@ def test_consensus_pecam1_cd38_direction() -> None:
 
 
 def test_consensus_excludes_smad3_receptor() -> None:
-    # https://github.com/scverse/liana-py/issues/218
+    # https://github.com/scverse/liana/issues/218
     # SMAD3 is an intracellular transcription factor, not a membrane receptor,
     # so it must not appear as a receptor in the consensus resource.
     resource = select_resource("consensus")


### PR DESCRIPTION
Replaces the README-as-landing-page with a card grid, captioned toctrees and a grouped tutorial gallery led by the decision tree, on the scanpydoc theme with a light and dark palette derived from the logo (crimson, navy, turquoise).
Also renames the GitHub URLs from scverse/liana-py to scverse/liana and refreshes the installation page.