### PR TITLE
Run the tutorial notebooks in CI

### DIFF
--- a/.github/workflows/test_tutorials.yaml
+++ b/.github/workflows/test_tutorials.yaml
@@ -1,0 +1,94 @@
+name: Test tutorials
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  # Execute every tutorial notebook in its own runner. The notebooks live in the docs/tutorials
+  # submodule, so the test suite does not cover them, and the docs build renders them with
+  # `nb_execution_mode = "off"`.
+  tutorials:
+    strategy:
+      fail-fast: false
+      matrix:
+        notebook:
+          - basic_usage.ipynb
+          - prior_knowledge.ipynb
+          - targeted.ipynb
+          # pycrosstalker >=2 pins `anndata<0.13` and `pandas==2.2.2`, which liana cannot satisfy, and
+          # the 1.0.1 that resolves instead no longer ships the `from_liana` reader the notebook calls.
+          # - liana_pyCrossTalkeR.ipynb
+          - mofatalk.ipynb
+          - mofacellular.ipynb
+          - liana_c2c.ipynb
+          - bivariate.ipynb
+          - misty.ipynb
+          - sc_multi.ipynb
+          - sma.ipynb
+          # The three notebooks below run on the ~1GB, ~4M cell MERFISH atlas (`li.ds.yao_2023`),
+          # which does not fit a standard runner within a sensible time budget. Re-enable them
+          # once they start from a subsampled slide.
+          # - inflow_score.ipynb
+          # - inflow_mofaflex.ipynb
+          # - LRIC_tutorial.ipynb
+
+    name: ${{ matrix.notebook }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    env:
+      MPLBACKEND: agg
+      # nbconvert executes a notebook in the notebook's own directory, which is where `li.ds` caches.
+      DATASET_DIR: docs/tutorials/notebooks/data
+
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          filter: blob:none
+          fetch-depth: 0
+          submodules: true
+          persist-credentials: false
+      - uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
+        with:
+          enable-cache: true
+          cache-dependency-glob: pyproject.toml
+      - name: Cache the downloaded datasets
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ${{ env.DATASET_DIR }}
+          key: ${{ runner.os }}-liana-datasets-${{ hashFiles('src/liana/datasets/registry.yaml') }}
+          restore-keys: ${{ runner.os }}-liana-datasets-
+      - name: Install graphviz
+        # `targeted.ipynb` renders corneto's causal network, which shells out to `dot`.
+        run: sudo apt-get update && sudo apt-get install --no-install-recommends -y graphviz
+      - name: Install the tutorial dependencies
+        run: uv sync --extra tutorials-gpu
+      - name: List all installed package versions
+        run: uv pip list
+      - name: Execute ${{ matrix.notebook }}
+        run: |
+          uv run --with nbconvert --with ipykernel \
+            jupyter nbconvert --to notebook --execute \
+            --ExecutePreprocessor.timeout=1200 \
+            --output-dir "${RUNNER_TEMP}/executed" \
+            "docs/tutorials/notebooks/${{ matrix.notebook }}"
+
+  check:
+    name: All tutorials run
+    if: always()
+    needs: tutorials
+    runs-on: ubuntu-latest
+    steps:
+      - uses: re-actors/alls-green@b5b5b37504aa4183270bd3d855c52a67f212be35 # v1.3.0
+        with:
+          jobs: ${{ toJSON(needs) }}

--- a/.github/workflows/test_tutorials.yaml
+++ b/.github/workflows/test_tutorials.yaml
@@ -15,9 +15,6 @@ permissions:
   contents: read
 
 jobs:
-  # Execute every tutorial notebook in its own runner. The notebooks live in the docs/tutorials
-  # submodule, so the test suite does not cover them, and the docs build renders them with
-  # `nb_execution_mode = "off"`.
   tutorials:
     strategy:
       fail-fast: false
@@ -26,8 +23,7 @@ jobs:
           - basic_usage.ipynb
           - prior_knowledge.ipynb
           - targeted.ipynb
-          # pycrosstalker >=2 pins `anndata<0.13` and `pandas==2.2.2`, which liana cannot satisfy, and
-          # the 1.0.1 that resolves instead no longer ships the `from_liana` reader the notebook calls.
+          # pycrosstalker >=2 pins `anndata<0.13` and `pandas==2.2.2`, which liana cannot satisfy, and the 1.0.1 that resolves instead no longer ships the `from_liana` reader the notebook calls.
           # - liana_pyCrossTalkeR.ipynb
           - mofatalk.ipynb
           - mofacellular.ipynb
@@ -36,9 +32,8 @@ jobs:
           - misty.ipynb
           - sc_multi.ipynb
           - sma.ipynb
-          # The three notebooks below run on the ~1GB, ~4M cell MERFISH atlas (`li.ds.yao_2023`),
-          # which does not fit a standard runner within a sensible time budget. Re-enable them
-          # once they start from a subsampled slide.
+          # The three notebooks below run on the ~1GB, ~4M cell MERFISH atlas (`li.ds.yao_2023`), which does not fit a standard runner within a sensible time budget.
+          # Re-enable them once they start from a subsampled slide.
           # - inflow_score.ipynb
           # - inflow_mofaflex.ipynb
           # - LRIC_tutorial.ipynb
@@ -48,7 +43,6 @@ jobs:
     timeout-minutes: 30
     env:
       MPLBACKEND: agg
-      # nbconvert executes a notebook in the notebook's own directory, which is where `li.ds` caches.
       DATASET_DIR: docs/tutorials/notebooks/data
 
     steps:
@@ -69,7 +63,6 @@ jobs:
           key: ${{ runner.os }}-liana-datasets-${{ hashFiles('src/liana/datasets/registry.yaml') }}
           restore-keys: ${{ runner.os }}-liana-datasets-
       - name: Install graphviz
-        # `targeted.ipynb` renders corneto's causal network, which shells out to `dot`.
         run: sudo apt-get update && sudo apt-get install --no-install-recommends -y graphviz
       - name: Install the tutorial dependencies
         run: uv sync --extra tutorials-gpu

--- a/docs/about/background.md
+++ b/docs/about/background.md
@@ -1,14 +1,14 @@
 # About LIANA+
 
 LIANA+ scores cell-cell interactions in single-cell, spatially-resolved and multi-modal data.
-The methods it covers were published as separate tools that take different inputs and return different outputs; LIANA+ reimplements them behind one interface, on {class}`~anndata.AnnData` and {class}`~mudata.MuData`.
+The methods it covers were published as separate tools that take different inputs and return different outputs; LIANA+ reimplements them behind one interface {cite:p}`Dimitrov_2024`, on {class}`~anndata.AnnData` {cite:p}`Virshup_2024` and {class}`~mudata.MuData` {cite:p}`Bredikhin_2022`.
 If you use it in your work, see {doc}`cite`.
 
 ## Design
 
 ### One interface, many methods
 
-The methods often disagree, and which one is appropriate depends on the data and the question.
+The methods often disagree, and which one is appropriate depends on the data and the question {cite:p}`Dimitrov_2022`.
 LIANA+ reimplements the scoring functions of CellPhoneDB, CellChat, Connectome, NATMI, SingleCellSignalR and scSeqComm, along with a log-fold-change score and a geometric mean, so that they take the same input, use the same permutation scheme and return the same table.
 That makes the scores comparable, and {meth}`li.mt.rank_aggregate <liana.mt.rank_aggregate.__call__>` combines them into a rank consensus.
 
@@ -21,9 +21,9 @@ A new resource therefore works with every method, and a new method with every re
 ### More than one dissociated dataset
 
 The same scoring machinery covers three further settings.
-In spatially-resolved data, interactions can be restricted to spatial neighborhoods, scored per spot or cell with the bivariate metrics, or modelled as spatial relationships with {class}`li.mt.MistyData <liana.mt.MistyData>` and {meth}`li.mt.lric <liana.mt.lric.__call__>`.
+In spatially-resolved data, interactions can be restricted to spatial neighborhoods, scored per spot or cell with the bivariate metrics, or modelled as spatial relationships with {class}`li.mt.MistyData <liana.mt.MistyData>` {cite:p}`Tanevski_2022` and {meth}`li.mt.lric <liana.mt.lric.__call__>`.
 In multi-modal data, the ligand and the receptor can come from different modalities, such as transcriptome and surface protein, or transcriptome and MALDI-MSI metabolite.
-Across samples or conditions, interaction scores can be reshaped into views and factorized with MOFA or tensor-cell2cell, which summarises a collection of samples as a few communication programs.
+Across samples or conditions, interaction scores can be reshaped into views and factorized with MOFA {cite:p}`Argelaguet_2020` or tensor-cell2cell {cite:p}`Armingol_2022`, which summarises a collection of samples as a few communication programs.
 
 ### Downstream of the receptor
 
@@ -32,8 +32,8 @@ A ligand-receptor hit on its own says little about the mechanism behind it.
 
 ## Ecosystem
 
-LIANA+ is built on [anndata](https://anndata.readthedocs.io/) and [mudata](https://mudata.readthedocs.io/), and is used together with [scanpy](https://scanpy.readthedocs.io/), [squidpy](https://squidpy.readthedocs.io/), [decoupler](https://decoupler.readthedocs.io/), [omnipath](https://omnipathdb.org/), [MOFA](https://biofam.github.io/MOFA2/), [tensor-cell2cell](https://earmingol.github.io/cell2cell/) and [corneto](https://saezlab.github.io/corneto/).
-The [Saez-Rodriguez group](https://saezlab.org/) develops it, and it is part of the [scverse ecosystem](https://scverse.org/).
+LIANA+ is built on [anndata](https://anndata.readthedocs.io/) {cite:p}`Virshup_2024` and [mudata](https://mudata.readthedocs.io/) {cite:p}`Bredikhin_2022`, and is used together with [scanpy](https://scanpy.readthedocs.io/) {cite:p}`Wolf_2018`, [squidpy](https://squidpy.readthedocs.io/) {cite:p}`Palla_2022`, [decoupler](https://decoupler.readthedocs.io/) {cite:p}`Badia_i_Mompel_2022`, [omnipath](https://omnipathdb.org/) {cite:p}`T_rei_2021`, [MOFA](https://biofam.github.io/MOFA2/) {cite:p}`Argelaguet_2020`, [tensor-cell2cell](https://earmingol.github.io/cell2cell/) {cite:p}`Armingol_2022` and [corneto](https://saezlab.github.io/corneto/).
+The [Saez-Rodriguez group](https://saezlab.org/) develops it, and it is part of the [scverse ecosystem](https://scverse.org/) {cite:p}`Virshup_2023`.
 
 ## Why LIANA+?
 

--- a/docs/about/cite.md
+++ b/docs/about/cite.md
@@ -1,6 +1,6 @@
 # Citation
 
-Please cite the framework paper, and the 2022 benchmark if you use the methods or resources it compared:
+Please cite the framework paper {cite:p}`Dimitrov_2024`, and the 2022 benchmark {cite:p}`Dimitrov_2022` if you use the methods or resources it compared:
 
 ```bibtex
 @article{Dimitrov2024,

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -24,7 +24,7 @@ sys.path.insert(0, str(HERE / "extensions"))
 info = metadata("liana")
 project_name = info["Name"]
 author = info["Author"]
-copyright = f"{datetime.now():%Y}, {author}."
+copyright = f"{datetime.now():%Y}, the LIANA+ developers"
 version = info["Version"]
 urls = dict(pu.split(", ") for pu in info.get_all("Project-URL"))
 repository_url = urls["Source"]
@@ -158,6 +158,7 @@ html_theme_options = {
     # The crimson of the logo. scanpydoc exposes it as the `--accent-color` CSS variable, which colors the mobile header and the project name.
     "accent_color": "#ba1b57",
     "show_toc_level": 2,
+    "footer_content_items": ["copyright.html"],
 }
 
 pygments_style = "default"

--- a/docs/references.bib
+++ b/docs/references.bib
@@ -8,3 +8,116 @@
 	title = {The scverse project provides a computational ecosystem for single-cell omics data analysis},
 	journal = {Nature Biotechnology}
 }
+
+@article{Virshup_2024,
+	title={anndata: Access and store annotated data matrices},
+	volume={9},
+	DOI={10.21105/joss.04371},
+	number={101},
+	journal={Journal of Open Source Software},
+	author={Virshup, Isaac and Rybakov, Sergei and Theis, Fabian J. and Angerer, Philipp and Wolf, F. Alexander},
+	year={2024},
+	pages={4371}
+}
+
+@article{Wolf_2018,
+	title={SCANPY: large-scale single-cell gene expression data analysis},
+	volume={19},
+	DOI={10.1186/s13059-017-1382-0},
+	number={1},
+	journal={Genome Biology},
+	author={Wolf, F. Alexander and Angerer, Philipp and Theis, Fabian J.},
+	year={2018}
+}
+
+@article{Bredikhin_2022,
+	title={MUON: multimodal omics analysis framework},
+	volume={23},
+	DOI={10.1186/s13059-021-02577-8},
+	number={1},
+	journal={Genome Biology},
+	author={Bredikhin, Danila and Kats, Ilia and Stegle, Oliver},
+	year={2022}
+}
+
+@article{Palla_2022,
+	title={Squidpy: a scalable framework for spatial omics analysis},
+	volume={19},
+	DOI={10.1038/s41592-021-01358-2},
+	number={2},
+	journal={Nature Methods},
+	author={Palla, Giovanni and Spitzer, Hannah and Klein, Michal and Fischer, David and Schaar, Anna Christina and Kuemmerle, Louis Benedikt and Rybakov, Sergei and Ibarra, Ignacio L. and Holmberg, Olle and Virshup, Isaac and Lotfollahi, Mohammad and Richter, Sabrina and Theis, Fabian J.},
+	year={2022},
+	pages={171–178}
+}
+
+@article{Badia_i_Mompel_2022,
+	title={decoupleR: ensemble of computational methods to infer biological activities from omics data},
+	volume={2},
+	DOI={10.1093/bioadv/vbac016},
+	number={1},
+	journal={Bioinformatics Advances},
+	author={Badia-i-Mompel, Pau and Vélez Santiago, Jesús and Braunger, Jana and Geiss, Celina and Dimitrov, Daniel and Müller-Dott, Sophia and Taus, Petr and Dugourd, Aurelien and Holland, Christian H and Ramirez Flores, Ricardo O and Saez-Rodriguez, Julio},
+	year={2022}
+}
+
+@article{T_rei_2021,
+	title={Integrated intra‐ and intercellular signaling knowledge for multicellular omics analysis},
+	volume={17},
+	DOI={10.15252/msb.20209923},
+	number={3},
+	journal={Molecular Systems Biology},
+	author={Türei, Dénes and Valdeolivas, Alberto and Gul, Lejla and Palacio‐Escat, Nicolàs and Klein, Michal and Ivanova, Olga and Ölbei, Márton and Gábor, Attila and Theis, Fabian and Módos, Dezső and Korcsmáros, Tamás and Saez‐Rodriguez, Julio},
+	year={2021}
+}
+
+@article{Argelaguet_2020,
+	title={MOFA+: a statistical framework for comprehensive integration of multi-modal single-cell data},
+	volume={21},
+	DOI={10.1186/s13059-020-02015-1},
+	number={1},
+	journal={Genome Biology},
+	author={Argelaguet, Ricard and Arnol, Damien and Bredikhin, Danila and Deloro, Yonatan and Velten, Britta and Marioni, John C. and Stegle, Oliver},
+	year={2020}
+}
+
+@article{Armingol_2022,
+	title={Context-aware deconvolution of cell–cell communication with Tensor-cell2cell},
+	volume={13},
+	DOI={10.1038/s41467-022-31369-2},
+	number={1},
+	journal={Nature Communications},
+	author={Armingol, Erick and Baghdassarian, Hratch M. and Martino, Cameron and Perez-Lopez, Araceli and Aamodt, Caitlin and Knight, Rob and Lewis, Nathan E.},
+	year={2022}
+}
+
+@article{Tanevski_2022,
+	title={Explainable multiview framework for dissecting spatial relationships from highly multiplexed data},
+	volume={23},
+	DOI={10.1186/s13059-022-02663-5},
+	number={1},
+	journal={Genome Biology},
+	author={Tanevski, Jovan and Flores, Ricardo Omar Ramirez and Gabor, Attila and Schapiro, Denis and Saez-Rodriguez, Julio},
+	year={2022}
+}
+
+@article{Dimitrov_2024,
+	title={LIANA+ provides an all-in-one framework for cell–cell communication inference},
+	volume={26},
+	DOI={10.1038/s41556-024-01469-w},
+	number={9},
+	journal={Nature Cell Biology},
+	author={Dimitrov, Daniel and Schäfer, Philipp Sven Lars and Farr, Elias and Rodriguez-Mier, Pablo and Lobentanzer, Sebastian and Badia-i-Mompel, Pau and Dugourd, Aurelien and Tanevski, Jovan and Ramirez Flores, Ricardo Omar and Saez-Rodriguez, Julio},
+	year={2024},
+	pages={1613–1622}
+}
+
+@article{Dimitrov_2022,
+	title={Comparison of methods and resources for cell-cell communication inference from single-cell RNA-Seq data},
+	volume={13},
+	DOI={10.1038/s41467-022-30755-0},
+	number={1},
+	journal={Nature Communications},
+	author={Dimitrov, Daniel and Türei, Dénes and Garrido-Rodriguez, Martin and Burmedi, Paul L. and Nagai, James S. and Boys, Charlotte and Ramirez Flores, Ricardo O. and Kim, Hyojin and Szalai, Bence and Costa, Ivan G. and Valdeolivas, Alberto and Dugourd, Aurélien and Saez-Rodriguez, Julio},
+	year={2022}
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ authors = [
   { name = "Aurelien Dugourd" },
   { name = "Jovan Tanevski" },
   { name = "Ricardo Omar Ramirez Flores" },
+  { name = "Lukas Heumos" },
   { name = "Julio Saez-Rodriguez" },
 ]
 requires-python = ">=3.12"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,7 +63,7 @@ optional-dependencies.extras = [
 # = extras (liana features) + notebook-only viz/runtime packages not imported by src.
 optional-dependencies.tutorials = [
   "adjusttext",
-  "graphviz",      # targeted.ipynb renders the causal network with corneto's carnival visualiser
+  "graphviz",
   "liana[extras]",
   "marsilea",
   "matplotlib",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,6 +63,7 @@ optional-dependencies.extras = [
 # = extras (liana features) + notebook-only viz/runtime packages not imported by src.
 optional-dependencies.tutorials = [
   "adjusttext",
+  "graphviz",      # targeted.ipynb renders the causal network with corneto's carnival visualiser
   "liana[extras]",
   "marsilea",
   "matplotlib",

--- a/src/liana/datasets/datasets.py
+++ b/src/liana/datasets/datasets.py
@@ -56,7 +56,6 @@ def kang_2018() -> AnnData:
         "Dendritic cells": "DCs",
         "Megakaryocytes": "Mega",
     }
-    # `cell_type` is categorical, and replacing its categories one by one is an error in pandas >=3
     obs["cell_abbr"] = obs["cell_type"].astype(str).replace(abbreviations).astype("category")
 
     return adata

--- a/src/liana/datasets/datasets.py
+++ b/src/liana/datasets/datasets.py
@@ -56,7 +56,8 @@ def kang_2018() -> AnnData:
         "Dendritic cells": "DCs",
         "Megakaryocytes": "Mega",
     }
-    obs["cell_abbr"] = obs["cell_type"].replace(abbreviations)
+    # `cell_type` is categorical, and replacing its categories one by one is an error in pandas >=3
+    obs["cell_abbr"] = obs["cell_type"].astype(str).replace(abbreviations).astype("category")
 
     return adata
 

--- a/src/liana/method/sp/_misty/_Misty.py
+++ b/src/liana/method/sp/_misty/_Misty.py
@@ -7,6 +7,7 @@ import numpy as np
 import pandas as pd
 from anndata import AnnData
 from fast_array_utils.conv import to_dense
+from fast_array_utils.types import CSBase
 from mudata import MuData
 from numpy.typing import NDArray
 from sklearn.linear_model import LinearRegression, RidgeCV
@@ -141,8 +142,10 @@ class MistyData(MuData):
             connectivities = view.obsp[f"{self.spatial_key}_connectivities"]
             view.layers["weighted"] = _to_matrix(connectivities @ X, what="weighted layer")
         else:
-            weights = np.asarray(view.obsm[f"{self.spatial_key}_connectivities"]).T
-            view.varm["weighted"] = np.asarray(weights @ X).T
+            # `np.asarray` on a sparse `obsm` gives a 0-d object array, which cannot be multiplied.
+            weights = _to_matrix(view.obsm[f"{self.spatial_key}_connectivities"], what="spatial connectivities").T
+            weighted = (weights @ X).T
+            view.varm["weighted"] = weighted.tocsr() if isinstance(weighted, CSBase) else np.asarray(weighted)
 
     def get_weighted_matrix(self, view_name: str, predictors: list[str] | None = None) -> MatrixLike:
         """

--- a/src/liana/method/sp/_misty/_Misty.py
+++ b/src/liana/method/sp/_misty/_Misty.py
@@ -142,7 +142,6 @@ class MistyData(MuData):
             connectivities = view.obsp[f"{self.spatial_key}_connectivities"]
             view.layers["weighted"] = _to_matrix(connectivities @ X, what="weighted layer")
         else:
-            # `np.asarray` on a sparse `obsm` gives a 0-d object array, which cannot be multiplied.
             weights = _to_matrix(view.obsm[f"{self.spatial_key}_connectivities"], what="spatial connectivities").T
             weighted = (weights @ X).T
             view.varm["weighted"] = weighted.tocsr() if isinstance(weighted, CSBase) else np.asarray(weighted)


### PR DESCRIPTION
Adds `test_tutorials.yaml`, which executes each tutorial notebook in its own runner and caches the datasets `li.ds` downloads.
Running them locally surfaced three breakages that are fixed here (a pandas >=3 error in `li.ds.kang_2018`, an `np.asarray` around the sparse connectivities in `MistyData`, and the missing graphviz dependency of `targeted.ipynb`); `liana_pyCrossTalkeR.ipynb` and the three MERFISH notebooks are commented out of the matrix with the reason next to each, and the submodule points at scverse/liana-tutorials#3, which has to be merged first.

Closes #195