### PR TITLE
Fix spatial weighting, compile the hot loops, tidy the API

### DIFF
--- a/.github/workflows/test_tutorials.yaml
+++ b/.github/workflows/test_tutorials.yaml
@@ -1,0 +1,94 @@
+name: Test tutorials
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  # Execute every tutorial notebook in its own runner. The notebooks live in the docs/tutorials
+  # submodule, so the test suite does not cover them, and the docs build renders them with
+  # `nb_execution_mode = "off"`.
+  tutorials:
+    strategy:
+      fail-fast: false
+      matrix:
+        notebook:
+          - basic_usage.ipynb
+          - prior_knowledge.ipynb
+          - targeted.ipynb
+          # pycrosstalker >=2 pins `anndata<0.13` and `pandas==2.2.2`, which liana cannot satisfy, and
+          # the 1.0.1 that resolves instead no longer ships the `from_liana` reader the notebook calls.
+          # - liana_pyCrossTalkeR.ipynb
+          - mofatalk.ipynb
+          - mofacellular.ipynb
+          - liana_c2c.ipynb
+          - bivariate.ipynb
+          - misty.ipynb
+          - sc_multi.ipynb
+          - sma.ipynb
+          # The three notebooks below run on the ~1GB, ~4M cell MERFISH atlas (`li.ds.yao_2023`),
+          # which does not fit a standard runner within a sensible time budget. Re-enable them
+          # once they start from a subsampled slide.
+          # - inflow_score.ipynb
+          # - inflow_mofaflex.ipynb
+          # - LRIC_tutorial.ipynb
+
+    name: ${{ matrix.notebook }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    env:
+      MPLBACKEND: agg
+      # nbconvert executes a notebook in the notebook's own directory, which is where `li.ds` caches.
+      DATASET_DIR: docs/tutorials/notebooks/data
+
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          filter: blob:none
+          fetch-depth: 0
+          submodules: true
+          persist-credentials: false
+      - uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
+        with:
+          enable-cache: true
+          cache-dependency-glob: pyproject.toml
+      - name: Cache the downloaded datasets
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ${{ env.DATASET_DIR }}
+          key: ${{ runner.os }}-liana-datasets-${{ hashFiles('src/liana/datasets/registry.yaml') }}
+          restore-keys: ${{ runner.os }}-liana-datasets-
+      - name: Install graphviz
+        # `targeted.ipynb` renders corneto's causal network, which shells out to `dot`.
+        run: sudo apt-get update && sudo apt-get install --no-install-recommends -y graphviz
+      - name: Install the tutorial dependencies
+        run: uv sync --extra tutorials-gpu
+      - name: List all installed package versions
+        run: uv pip list
+      - name: Execute ${{ matrix.notebook }}
+        run: |
+          uv run --with nbconvert --with ipykernel \
+            jupyter nbconvert --to notebook --execute \
+            --ExecutePreprocessor.timeout=1200 \
+            --output-dir "${RUNNER_TEMP}/executed" \
+            "docs/tutorials/notebooks/${{ matrix.notebook }}"
+
+  check:
+    name: All tutorials run
+    if: always()
+    needs: tutorials
+    runs-on: ubuntu-latest
+    steps:
+      - uses: re-actors/alls-green@b5b5b37504aa4183270bd3d855c52a67f212be35 # v1.3.0
+        with:
+          jobs: ${{ toJSON(needs) }}

--- a/.github/workflows/test_tutorials.yaml
+++ b/.github/workflows/test_tutorials.yaml
@@ -15,9 +15,6 @@ permissions:
   contents: read
 
 jobs:
-  # Execute every tutorial notebook in its own runner. The notebooks live in the docs/tutorials
-  # submodule, so the test suite does not cover them, and the docs build renders them with
-  # `nb_execution_mode = "off"`.
   tutorials:
     strategy:
       fail-fast: false
@@ -26,8 +23,7 @@ jobs:
           - basic_usage.ipynb
           - prior_knowledge.ipynb
           - targeted.ipynb
-          # pycrosstalker >=2 pins `anndata<0.13` and `pandas==2.2.2`, which liana cannot satisfy, and
-          # the 1.0.1 that resolves instead no longer ships the `from_liana` reader the notebook calls.
+          # pycrosstalker >=2 pins `anndata<0.13` and `pandas==2.2.2`, which liana cannot satisfy, and the 1.0.1 that resolves instead no longer ships the `from_liana` reader the notebook calls.
           # - liana_pyCrossTalkeR.ipynb
           - mofatalk.ipynb
           - mofacellular.ipynb
@@ -36,9 +32,8 @@ jobs:
           - misty.ipynb
           - sc_multi.ipynb
           - sma.ipynb
-          # The three notebooks below run on the ~1GB, ~4M cell MERFISH atlas (`li.ds.yao_2023`),
-          # which does not fit a standard runner within a sensible time budget. Re-enable them
-          # once they start from a subsampled slide.
+          # The three notebooks below run on the ~1GB, ~4M cell MERFISH atlas (`li.ds.yao_2023`), which does not fit a standard runner within a sensible time budget.
+          # Re-enable them once they start from a subsampled slide.
           # - inflow_score.ipynb
           # - inflow_mofaflex.ipynb
           # - LRIC_tutorial.ipynb
@@ -48,7 +43,6 @@ jobs:
     timeout-minutes: 30
     env:
       MPLBACKEND: agg
-      # nbconvert executes a notebook in the notebook's own directory, which is where `li.ds` caches.
       DATASET_DIR: docs/tutorials/notebooks/data
 
     steps:
@@ -69,7 +63,6 @@ jobs:
           key: ${{ runner.os }}-liana-datasets-${{ hashFiles('src/liana/datasets/registry.yaml') }}
           restore-keys: ${{ runner.os }}-liana-datasets-
       - name: Install graphviz
-        # `targeted.ipynb` renders corneto's causal network, which shells out to `dot`.
         run: sudo apt-get update && sudo apt-get install --no-install-recommends -y graphviz
       - name: Install the tutorial dependencies
         run: uv sync --extra tutorials-gpu

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 - **Permutation nulls are built by compiled kernels instead of `joblib`.** Both the mean and the trimean null read the CSR buffers directly, one pass over the non-zeros per permutation, and never materialise a permuted copy of the matrix; the trimean sorts each gene's stored entries rather than densifying the group. On 50k cells x 600 genes x 200 permutations, the mean null goes from 2.8 s to 0.45 s and CellChat's trimean null from 68 s to 4.5 s (8 threads). `n_jobs` previously made the permutations *slower* than serial, because a task per permutation re-pickled the sparse matrix each time. Results are unchanged for the trimean and now depend only on `seed`, never on `n_jobs`; the mean null sums in double precision where it previously inherited scipy's single-precision accumulation.
 
-- **`liana.pl` plot names follow one convention.** Plot functions are bare nouns, as in `scanpy.pl`, and carry the prefix of the method they belong to when they only apply to it. The old names still resolve with a `FutureWarning`:
+- **`liana.pl` plot names follow one convention.** Plot functions are bare nouns, as in `scanpy.pl`, and carry the prefix of the method they belong to when they only apply to it. The old names still resolve, via `scverse_misc.deprecated`, so a type checker flags them and calling one raises a `FutureWarning`:
 
   | Was | Now |
   |---|---|

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 - **Permutation nulls are built by compiled kernels instead of `joblib`.** Both the mean and the trimean null read the CSR buffers directly, one pass over the non-zeros per permutation, and never materialise a permuted copy of the matrix; the trimean sorts each gene's stored entries rather than densifying the group. On 50k cells x 600 genes x 200 permutations, the mean null goes from 2.8 s to 0.45 s and CellChat's trimean null from 68 s to 4.5 s (8 threads). `n_jobs` previously made the permutations *slower* than serial, because a task per permutation re-pickled the sparse matrix each time. Results are unchanged for the trimean and now depend only on `seed`, never on `n_jobs`; the mean null sums in double precision where it previously inherited scipy's single-precision accumulation.
 
+- **A sample carrying a single cluster now yields `p = 1` throughout.** Every permutation leaves that cluster's membership untouched, so it has to score exactly as the observation does, but the observed and permuted sides are accumulated by different routines and the tie did not survive that. Permuted scores within single-precision resolution of the observed one now count as tied. Only reachable where a `sample_key` split, or `min_cells`, leaves one cluster standing; on the toy data this moved 9 of 2115 `by_sample` rows off values that were pure float noise.
+
 - **`liana.pl` plot names follow one convention.** Plot functions are bare nouns, as in `scanpy.pl`, and carry the prefix of the method they belong to when they only apply to it. The old names still resolve, via `scverse_misc.deprecated`, so a type checker flags them and calling one raises a `FutureWarning`:
 
   | Was | Now |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,35 @@
 # Changelog
 
+## Unreleased
+
+### Fixed
+
+- **Spatial proximity weighting now reaches the p-values of the permutation-based methods.** `spatial_key` weighted both the observed score and the permuted null by the same per-interaction factor, which cancels out of `perm * w >= obs * w` -- so on toy data 92.5% of CellPhoneDB p-values were bit-identical with and without weighting, and the rest only moved because a zero weight forced them to 1. Only the observed statistic is weighted now, so a spatially distant pair needs a correspondingly stronger expression signal to clear the null. Affects `li.mt.cellphonedb`, `li.mt.cellchat` and `li.mt.geometric_mean` when `spatial_key` is passed; magnitudes are unchanged.
+
+### Changed
+
+- **Permutation nulls are built by compiled kernels instead of `joblib`.** Both the mean and the trimean null read the CSR buffers directly, one pass over the non-zeros per permutation, and never materialise a permuted copy of the matrix; the trimean sorts each gene's stored entries rather than densifying the group. On 50k cells x 600 genes x 200 permutations, the mean null goes from 2.8 s to 0.45 s and CellChat's trimean null from 68 s to 4.5 s (8 threads). `n_jobs` previously made the permutations *slower* than serial, because a task per permutation re-pickled the sparse matrix each time. Results are unchanged for the trimean and now depend only on `seed`, never on `n_jobs`; the mean null sums in double precision where it previously inherited scipy's single-precision accumulation.
+
+- **`liana.pl` plot names follow one convention.** Plot functions are bare nouns, as in `scanpy.pl`, and carry the prefix of the method they belong to when they only apply to it. The old names still resolve with a `FutureWarning`:
+
+  | Was | Now |
+  |---|---|
+  | `li.pl.circle_plot` | `li.pl.circle` |
+  | `li.pl.annulus_plot` | `li.pl.annulus` |
+  | `li.pl.lric_divergence_plot` | `li.pl.lric_divergence` |
+  | `li.pl.target_metrics` | `li.pl.misty_target_metrics` |
+  | `li.pl.contributions` | `li.pl.misty_contributions` |
+  | `li.pl.interactions` | `li.pl.misty_interactions` |
+
+- **`liana_pipe` was split into named stages.** Assembling the ligand-receptor statistics, scoring them and aggregating across methods are now three functions rather than one 616-line one with five underscore-prefixed pseudo-private parameters. The consensus path has its own entry point (`liana_pipe_consensus`), so `liana_pipe` no longer dispatches on `_score.method_name == "Rank_Aggregate"` and always returns a `DataFrame`. Internal only -- `li.mt.*` and `li.mt.rank_aggregate` are unchanged.
+
+- **`li.mt.lric(pair_chunk=...)` is deprecated and ignored.** The weighted numerator is accumulated by a compiled kernel that holds no per-chunk temporaries, so there is nothing left to tune for memory. The same change makes it about 10x faster (3.7 s to 0.4 s on 2M edges x 500 pairs).
+
+- Locating ligands, receptors and cluster labels in the expression matrix uses `Index.get_indexer` instead of a `numpy.where` scan per interaction, which was quadratic in the number of interactions (1.42 s to 0.005 s for 60k interactions over 2k genes). An interaction naming a gene absent from `adata.var_names` now raises `KeyError` instead of silently indexing from the end.
+
+- Permutation progress bars track completed permutations. They previously wrapped the submission generator, so the bar filled immediately and then stalled.
+
+
 ## 2.0.0 (28.08.2026)
 
 ### Changed

--- a/docs/about/background.md
+++ b/docs/about/background.md
@@ -1,14 +1,14 @@
 # About LIANA+
 
 LIANA+ scores cell-cell interactions in single-cell, spatially-resolved and multi-modal data.
-The methods it covers were published as separate tools that take different inputs and return different outputs; LIANA+ reimplements them behind one interface, on {class}`~anndata.AnnData` and {class}`~mudata.MuData`.
+The methods it covers were published as separate tools that take different inputs and return different outputs; LIANA+ reimplements them behind one interface {cite:p}`Dimitrov_2024`, on {class}`~anndata.AnnData` {cite:p}`Virshup_2024` and {class}`~mudata.MuData` {cite:p}`Bredikhin_2022`.
 If you use it in your work, see {doc}`cite`.
 
 ## Design
 
 ### One interface, many methods
 
-The methods often disagree, and which one is appropriate depends on the data and the question.
+The methods often disagree, and which one is appropriate depends on the data and the question {cite:p}`Dimitrov_2022`.
 LIANA+ reimplements the scoring functions of CellPhoneDB, CellChat, Connectome, NATMI, SingleCellSignalR and scSeqComm, along with a log-fold-change score and a geometric mean, so that they take the same input, use the same permutation scheme and return the same table.
 That makes the scores comparable, and {meth}`li.mt.rank_aggregate <liana.mt.rank_aggregate.__call__>` combines them into a rank consensus.
 
@@ -21,9 +21,9 @@ A new resource therefore works with every method, and a new method with every re
 ### More than one dissociated dataset
 
 The same scoring machinery covers three further settings.
-In spatially-resolved data, interactions can be restricted to spatial neighborhoods, scored per spot or cell with the bivariate metrics, or modelled as spatial relationships with {class}`li.mt.MistyData <liana.mt.MistyData>` and {meth}`li.mt.lric <liana.mt.lric.__call__>`.
+In spatially-resolved data, interactions can be restricted to spatial neighborhoods, scored per spot or cell with the bivariate metrics, or modelled as spatial relationships with {class}`li.mt.MistyData <liana.mt.MistyData>` {cite:p}`Tanevski_2022` and {meth}`li.mt.lric <liana.mt.lric.__call__>`.
 In multi-modal data, the ligand and the receptor can come from different modalities, such as transcriptome and surface protein, or transcriptome and MALDI-MSI metabolite.
-Across samples or conditions, interaction scores can be reshaped into views and factorized with MOFA or tensor-cell2cell, which summarises a collection of samples as a few communication programs.
+Across samples or conditions, interaction scores can be reshaped into views and factorized with MOFA {cite:p}`Argelaguet_2020` or tensor-cell2cell {cite:p}`Armingol_2022`, which summarises a collection of samples as a few communication programs.
 
 ### Downstream of the receptor
 
@@ -32,8 +32,8 @@ A ligand-receptor hit on its own says little about the mechanism behind it.
 
 ## Ecosystem
 
-LIANA+ is built on [anndata](https://anndata.readthedocs.io/) and [mudata](https://mudata.readthedocs.io/), and is used together with [scanpy](https://scanpy.readthedocs.io/), [squidpy](https://squidpy.readthedocs.io/), [decoupler](https://decoupler.readthedocs.io/), [omnipath](https://omnipathdb.org/), [MOFA](https://biofam.github.io/MOFA2/), [tensor-cell2cell](https://earmingol.github.io/cell2cell/) and [corneto](https://saezlab.github.io/corneto/).
-The [Saez-Rodriguez group](https://saezlab.org/) develops it, and it is part of the [scverse ecosystem](https://scverse.org/).
+LIANA+ is built on [anndata](https://anndata.readthedocs.io/) {cite:p}`Virshup_2024` and [mudata](https://mudata.readthedocs.io/) {cite:p}`Bredikhin_2022`, and is used together with [scanpy](https://scanpy.readthedocs.io/) {cite:p}`Wolf_2018`, [squidpy](https://squidpy.readthedocs.io/) {cite:p}`Palla_2022`, [decoupler](https://decoupler.readthedocs.io/) {cite:p}`Badia_i_Mompel_2022`, [omnipath](https://omnipathdb.org/) {cite:p}`T_rei_2021`, [MOFA](https://biofam.github.io/MOFA2/) {cite:p}`Argelaguet_2020`, [tensor-cell2cell](https://earmingol.github.io/cell2cell/) {cite:p}`Armingol_2022` and [corneto](https://saezlab.github.io/corneto/).
+The [Saez-Rodriguez group](https://saezlab.org/) develops it, and it is part of the [scverse ecosystem](https://scverse.org/) {cite:p}`Virshup_2023`.
 
 ## Why LIANA+?
 

--- a/docs/about/cite.md
+++ b/docs/about/cite.md
@@ -1,6 +1,6 @@
 # Citation
 
-Please cite the framework paper, and the 2022 benchmark if you use the methods or resources it compared:
+Please cite the framework paper {cite:p}`Dimitrov_2024`, and the 2022 benchmark {cite:p}`Dimitrov_2022` if you use the methods or resources it compared:
 
 ```bibtex
 @article{Dimitrov2024,

--- a/docs/api.md
+++ b/docs/api.md
@@ -212,13 +212,13 @@ Passed as `model=` when calling a `MistyData` object:
     dotplot
     dotplot_by_sample
     tileplot
-    circle_plot
+    circle
     connectivity
-    target_metrics
-    contributions
-    interactions
-    annulus_plot
+    misty_target_metrics
+    misty_contributions
+    misty_interactions
+    annulus
     lric_lineplot
-    lric_divergence_plot
+    lric_divergence
     feature_by_group
 ```

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -24,7 +24,7 @@ sys.path.insert(0, str(HERE / "extensions"))
 info = metadata("liana")
 project_name = info["Name"]
 author = info["Author"]
-copyright = f"{datetime.now():%Y}, {author}."
+copyright = f"{datetime.now():%Y}, the LIANA+ developers"
 version = info["Version"]
 urls = dict(pu.split(", ") for pu in info.get_all("Project-URL"))
 repository_url = urls["Source"]
@@ -158,6 +158,7 @@ html_theme_options = {
     # The crimson of the logo. scanpydoc exposes it as the `--accent-color` CSS variable, which colors the mobile header and the project name.
     "accent_color": "#ba1b57",
     "show_toc_level": 2,
+    "footer_content_items": ["copyright.html"],
 }
 
 pygments_style = "default"

--- a/docs/references.bib
+++ b/docs/references.bib
@@ -8,3 +8,116 @@
 	title = {The scverse project provides a computational ecosystem for single-cell omics data analysis},
 	journal = {Nature Biotechnology}
 }
+
+@article{Virshup_2024,
+	title={anndata: Access and store annotated data matrices},
+	volume={9},
+	DOI={10.21105/joss.04371},
+	number={101},
+	journal={Journal of Open Source Software},
+	author={Virshup, Isaac and Rybakov, Sergei and Theis, Fabian J. and Angerer, Philipp and Wolf, F. Alexander},
+	year={2024},
+	pages={4371}
+}
+
+@article{Wolf_2018,
+	title={SCANPY: large-scale single-cell gene expression data analysis},
+	volume={19},
+	DOI={10.1186/s13059-017-1382-0},
+	number={1},
+	journal={Genome Biology},
+	author={Wolf, F. Alexander and Angerer, Philipp and Theis, Fabian J.},
+	year={2018}
+}
+
+@article{Bredikhin_2022,
+	title={MUON: multimodal omics analysis framework},
+	volume={23},
+	DOI={10.1186/s13059-021-02577-8},
+	number={1},
+	journal={Genome Biology},
+	author={Bredikhin, Danila and Kats, Ilia and Stegle, Oliver},
+	year={2022}
+}
+
+@article{Palla_2022,
+	title={Squidpy: a scalable framework for spatial omics analysis},
+	volume={19},
+	DOI={10.1038/s41592-021-01358-2},
+	number={2},
+	journal={Nature Methods},
+	author={Palla, Giovanni and Spitzer, Hannah and Klein, Michal and Fischer, David and Schaar, Anna Christina and Kuemmerle, Louis Benedikt and Rybakov, Sergei and Ibarra, Ignacio L. and Holmberg, Olle and Virshup, Isaac and Lotfollahi, Mohammad and Richter, Sabrina and Theis, Fabian J.},
+	year={2022},
+	pages={171–178}
+}
+
+@article{Badia_i_Mompel_2022,
+	title={decoupleR: ensemble of computational methods to infer biological activities from omics data},
+	volume={2},
+	DOI={10.1093/bioadv/vbac016},
+	number={1},
+	journal={Bioinformatics Advances},
+	author={Badia-i-Mompel, Pau and Vélez Santiago, Jesús and Braunger, Jana and Geiss, Celina and Dimitrov, Daniel and Müller-Dott, Sophia and Taus, Petr and Dugourd, Aurelien and Holland, Christian H and Ramirez Flores, Ricardo O and Saez-Rodriguez, Julio},
+	year={2022}
+}
+
+@article{T_rei_2021,
+	title={Integrated intra‐ and intercellular signaling knowledge for multicellular omics analysis},
+	volume={17},
+	DOI={10.15252/msb.20209923},
+	number={3},
+	journal={Molecular Systems Biology},
+	author={Türei, Dénes and Valdeolivas, Alberto and Gul, Lejla and Palacio‐Escat, Nicolàs and Klein, Michal and Ivanova, Olga and Ölbei, Márton and Gábor, Attila and Theis, Fabian and Módos, Dezső and Korcsmáros, Tamás and Saez‐Rodriguez, Julio},
+	year={2021}
+}
+
+@article{Argelaguet_2020,
+	title={MOFA+: a statistical framework for comprehensive integration of multi-modal single-cell data},
+	volume={21},
+	DOI={10.1186/s13059-020-02015-1},
+	number={1},
+	journal={Genome Biology},
+	author={Argelaguet, Ricard and Arnol, Damien and Bredikhin, Danila and Deloro, Yonatan and Velten, Britta and Marioni, John C. and Stegle, Oliver},
+	year={2020}
+}
+
+@article{Armingol_2022,
+	title={Context-aware deconvolution of cell–cell communication with Tensor-cell2cell},
+	volume={13},
+	DOI={10.1038/s41467-022-31369-2},
+	number={1},
+	journal={Nature Communications},
+	author={Armingol, Erick and Baghdassarian, Hratch M. and Martino, Cameron and Perez-Lopez, Araceli and Aamodt, Caitlin and Knight, Rob and Lewis, Nathan E.},
+	year={2022}
+}
+
+@article{Tanevski_2022,
+	title={Explainable multiview framework for dissecting spatial relationships from highly multiplexed data},
+	volume={23},
+	DOI={10.1186/s13059-022-02663-5},
+	number={1},
+	journal={Genome Biology},
+	author={Tanevski, Jovan and Flores, Ricardo Omar Ramirez and Gabor, Attila and Schapiro, Denis and Saez-Rodriguez, Julio},
+	year={2022}
+}
+
+@article{Dimitrov_2024,
+	title={LIANA+ provides an all-in-one framework for cell–cell communication inference},
+	volume={26},
+	DOI={10.1038/s41556-024-01469-w},
+	number={9},
+	journal={Nature Cell Biology},
+	author={Dimitrov, Daniel and Schäfer, Philipp Sven Lars and Farr, Elias and Rodriguez-Mier, Pablo and Lobentanzer, Sebastian and Badia-i-Mompel, Pau and Dugourd, Aurelien and Tanevski, Jovan and Ramirez Flores, Ricardo Omar and Saez-Rodriguez, Julio},
+	year={2024},
+	pages={1613–1622}
+}
+
+@article{Dimitrov_2022,
+	title={Comparison of methods and resources for cell-cell communication inference from single-cell RNA-Seq data},
+	volume={13},
+	DOI={10.1038/s41467-022-30755-0},
+	number={1},
+	journal={Nature Communications},
+	author={Dimitrov, Daniel and Türei, Dénes and Garrido-Rodriguez, Martin and Burmedi, Paul L. and Nagai, James S. and Boys, Charlotte and Ramirez Flores, Ricardo O. and Kim, Hyojin and Szalai, Bence and Costa, Ivan G. and Valdeolivas, Alberto and Dugourd, Aurélien and Saez-Rodriguez, Julio},
+	year={2022}
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ authors = [
   { name = "Aurelien Dugourd" },
   { name = "Jovan Tanevski" },
   { name = "Ricardo Omar Ramirez Flores" },
+  { name = "Lukas Heumos" },
   { name = "Julio Saez-Rodriguez" },
 ]
 requires-python = ">=3.12"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,7 +63,7 @@ optional-dependencies.extras = [
 # = extras (liana features) + notebook-only viz/runtime packages not imported by src.
 optional-dependencies.tutorials = [
   "adjusttext",
-  "graphviz",      # targeted.ipynb renders the causal network with corneto's carnival visualiser
+  "graphviz",
   "liana[extras]",
   "marsilea",
   "matplotlib",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,6 +63,7 @@ optional-dependencies.extras = [
 # = extras (liana features) + notebook-only viz/runtime packages not imported by src.
 optional-dependencies.tutorials = [
   "adjusttext",
+  "graphviz",      # targeted.ipynb renders the causal network with corneto's carnival visualiser
   "liana[extras]",
   "marsilea",
   "matplotlib",

--- a/src/liana/_core/_constants.py
+++ b/src/liana/_core/_constants.py
@@ -76,6 +76,7 @@ class CommonColumns:
     receptor_props: Final = "receptor_props"
     ligand_pvals: Final = "ligand_pvals"
     receptor_pvals: Final = "receptor_pvals"
+    proximity: Final = "proximity"
 
 
 class MethodColumns:

--- a/src/liana/_core/_pipe_utils/_get_mean_perms.py
+++ b/src/liana/_core/_pipe_utils/_get_mean_perms.py
@@ -1,12 +1,16 @@
 from __future__ import annotations
 
-from collections.abc import Callable
-from typing import TYPE_CHECKING
+from collections.abc import Callable, Iterable, Iterator, Sequence
+from contextlib import contextmanager, nullcontext
+from typing import TYPE_CHECKING, Literal
 
+import numba as nb
 import numpy as np
 import pandas as pd
+from fast_array_utils.types import CSBase
 from joblib import Parallel, delayed
 from numpy.typing import NDArray
+from scipy.sparse import csr_array, csr_matrix
 from tqdm import tqdm
 
 from liana._core._types import get_obs, get_x
@@ -14,7 +18,11 @@ from liana._core._types import get_obs, get_x
 if TYPE_CHECKING:
     from anndata import AnnData
 
+    prange = range
+
     from liana._core._types import MatrixLike
+else:
+    prange = nb.prange
 
 
 type _AggFn = Callable[..., NDArray[np.floating]]
@@ -25,12 +33,41 @@ ufunc-style overloads that no single explicit signature matches structurally;
 the return type is what callers rely on.
 """
 
+type Aggregation = Literal["mean", "trimean"]
+"""The location estimate a permutation-based method builds its null from."""
+
+_MAX_PERM_INDEX_ELEMENTS = 1 << 24
+"""Cap on how many row positions one block of permutations may hold, so that peak memory does not scale with ``n_perms``."""
+
+
+def _trimean(a: CSBase, axis: int = 0) -> NDArray[np.floating]:
+    """Tukey's trimean, the location estimate CellChat scores with."""
+    dense = a.toarray()
+    quantiles = np.quantile(dense, q=[0.25, 0.75], axis=axis)
+    median = np.median(dense, axis=axis)
+    return np.asarray((quantiles[0] + 2 * median + quantiles[1]) / 4)
+
+
+_AGG_FNS: dict[Aggregation, _AggFn] = {"mean": np.mean, "trimean": _trimean}
+
+
+@contextmanager
+def _numba_threads(n_jobs: int) -> Iterator[None]:
+    """Run the enclosed numba kernels on at most ``n_jobs`` threads, then restore the previous setting."""
+    available: int = nb.config.NUMBA_NUM_THREADS  # type: ignore[attr-defined]
+    previous = nb.get_num_threads()
+    nb.set_num_threads(available if n_jobs <= 0 else min(n_jobs, available))
+    try:
+        yield
+    finally:
+        nb.set_num_threads(previous)
+
 
 def _get_means_perms(
     adata: AnnData,
     n_perms: int,
     seed: int,
-    agg_fn: _AggFn,
+    aggregation: Aggregation,
     norm_factor: float | np.floating | None,
     n_jobs: int,
     verbose: bool,
@@ -46,8 +83,8 @@ def _get_means_perms(
         Number of permutations to be calculated
     seed
         Random seed for reproducibility.
-    agg_fn
-        Function by which to aggregate the matrix, should take `axis` argument
+    aggregation
+        Location estimate to aggregate each permuted cluster by, `'mean'` or `'trimean'`
     norm_factor
         Additionally normalize the data by some factor (e.g. matrix max for CellChat)
     n_jobs
@@ -57,11 +94,7 @@ def _get_means_perms(
 
     Returns
     -------
-    Tuple with:
-        - perms: 3D tensor with permuted averages per cluster
-        - ligand_pos: Index of the ligand in the tensor
-        - receptor_pos: Index of the receptor in the perms tensor
-        - labels_pos: Index of cell identities in the perms tensor
+    A `(n_perms, n_labels, n_genes)` tensor of permuted per-cluster aggregates.
     """
     X = get_x(adata)
     # gating on `isinstance(..., np.float32)` silently skipped a plain `float`
@@ -82,22 +115,162 @@ def _get_means_perms(
         labels_mask[:, ct_idx] = obs["@label"] == label
 
     # Perm should be a cube /w dims: n_perms x idents x n_genes
-    perms = _generate_perms_cube(X, n_perms, labels_mask, seed, agg_fn, n_jobs, verbose)
+    perms = _generate_perms_cube(X, n_perms, labels_mask, seed, aggregation, n_jobs, verbose)
 
     return perms
 
 
-# Define a helper function for parallel processing
+@nb.njit(cache=True)
+def _lerp(a: float, b: float, t: float) -> float:
+    """Interpolate between ``a`` and ``b``, the way :func:`numpy.quantile` does.
+
+    Approaching from whichever end is nearer keeps the result exact at ``t`` of 0 and 1, so the kernel reproduces numpy's quantiles bit for bit.
+    """
+    diff = b - a
+    if t >= 0.5:
+        return b - diff * (1.0 - t)
+    return a + diff * t
+
+
+@nb.njit(cache=True)
+def _sparse_quantile(values: NDArray[np.floating], n_zeros: int, n_total: int, q: float) -> float:
+    """Take the ``q``-th quantile of ``n_zeros`` zeros followed by the ascending ``values``.
+
+    A column of a sparse group is exactly that: its stored entries, plus one zero for every row that stored nothing.
+    Sorting only the stored entries makes the cost proportional to the non-zeros rather than to the number of cells.
+    """
+    pos = q * (n_total - 1)
+    lo = int(np.floor(pos))
+    hi = lo + 1 if lo + 1 < n_total else n_total - 1
+    a = np.float64(0.0) if lo < n_zeros else np.float64(values[lo - n_zeros])
+    b = np.float64(0.0) if hi < n_zeros else np.float64(values[hi - n_zeros])
+    return _lerp(a, b, pos - lo)
+
+
+@nb.njit(cache=True)
+def _sparse_trimean(values: NDArray[np.floating], n_zeros: int, n_total: int) -> float:
+    """Take Tukey's trimean of ``n_zeros`` zeros followed by the ascending ``values``."""
+    half = n_total // 2
+    if n_total % 2 == 1:
+        median = np.float32(0.0) if half < n_zeros else values[half - n_zeros]
+    else:
+        lower = np.float32(0.0) if half - 1 < n_zeros else values[half - 1 - n_zeros]
+        upper = np.float32(0.0) if half < n_zeros else values[half - n_zeros]
+        median = np.float32((lower + upper) / np.float32(2.0))
+
+    q25 = _sparse_quantile(values, n_zeros, n_total, 0.25)
+    q75 = _sparse_quantile(values, n_zeros, n_total, 0.75)
+
+    return (q25 + 2 * np.float64(median) + q75) / 4
+
+
+@nb.njit(parallel=True, cache=True)
+def _perm_group_sums(
+    data: NDArray[np.floating],
+    indices: NDArray[np.integer],
+    indptr: NDArray[np.integer],
+    perm_indices: NDArray[np.integer],
+    label_of_row: NDArray[np.integer],
+    n_labels: int,
+    n_genes: int,
+) -> NDArray[np.floating]:
+    """Sum the rows of a CSR matrix per label, once per permutation in ``perm_indices``.
+
+    Each permutation reassigns which cell sits at which position, so position ``j`` contributes row ``perm_indices[p, j]`` to the label that position ``j`` originally carried.
+    Accumulating straight out of the CSR buffers costs one pass over the non-zeros per permutation and never materialises a permuted copy of the matrix.
+    Sums are taken in double precision, where the gathered-rows fallback inherits scipy's single-precision accumulation.
+    """
+    n_perms, n_obs = perm_indices.shape
+    sums = np.zeros((n_perms, n_labels, n_genes), dtype=np.float64)
+
+    for p in prange(n_perms):
+        for j in range(n_obs):
+            label = label_of_row[j]
+            row = perm_indices[p, j]
+            for k in range(indptr[row], indptr[row + 1]):
+                sums[p, label, indices[k]] += data[k]
+
+    return sums
+
+
+@nb.njit(parallel=True, cache=True)
+def _perm_group_trimeans(
+    data: NDArray[np.floating],
+    indices: NDArray[np.integer],
+    indptr: NDArray[np.integer],
+    perm_indices: NDArray[np.integer],
+    order: NDArray[np.integer],
+    label_ptr: NDArray[np.integer],
+    n_genes: int,
+) -> NDArray[np.floating]:
+    """Take Tukey's trimean of the rows of a CSR matrix per label, once per permutation in ``perm_indices``.
+
+    ``order`` lists row positions grouped by label and ``label_ptr`` delimits those groups.
+    A group's non-zeros are bucketed by gene in one counting pass, so each gene's column is sorted on its own instead of densifying the whole group.
+    """
+    n_perms = perm_indices.shape[0]
+    n_labels = label_ptr.shape[0] - 1
+    trimeans = np.zeros((n_perms, n_labels, n_genes), dtype=np.float64)
+
+    for p in prange(n_perms):
+        offsets = np.empty(n_genes + 1, dtype=np.int64)
+        for label in range(n_labels):
+            start, stop = label_ptr[label], label_ptr[label + 1]
+            n_in_label = stop - start
+
+            offsets[:] = 0
+            for position in range(start, stop):
+                row = perm_indices[p, order[position]]
+                for k in range(indptr[row], indptr[row + 1]):
+                    offsets[indices[k] + 1] += 1
+            for gene in range(n_genes):
+                offsets[gene + 1] += offsets[gene]
+
+            values = np.empty(offsets[n_genes], dtype=data.dtype)
+            cursor = offsets[:n_genes].copy()
+            for position in range(start, stop):
+                row = perm_indices[p, order[position]]
+                for k in range(indptr[row], indptr[row + 1]):
+                    gene = indices[k]
+                    values[cursor[gene]] = data[k]
+                    cursor[gene] += 1
+
+            for gene in range(n_genes):
+                column = values[offsets[gene] : offsets[gene + 1]]
+                column.sort()
+                trimeans[p, label, gene] = _sparse_trimean(column, n_in_label - column.size, n_in_label)
+
+    return trimeans
+
+
 def _permute_and_aggregate(
-    perm: int,
-    perm_idx: NDArray[np.integer],
+    perm_indices: NDArray[np.integer],
     X: MatrixLike,
-    labels_mask: NDArray[np.bool_],
+    label_rows: Sequence[NDArray[np.integer]],
     agg_fn: _AggFn,
-) -> tuple[int, NDArray[np.floating]]:
-    perm_mat = X[perm_idx]
-    permuted_means = np.array([agg_fn(perm_mat[labels_mask[:, i]], axis=0) for i in range(labels_mask.shape[1])])
-    return perm, permuted_means
+) -> NDArray[np.floating]:
+    """Aggregate ``X`` per label under each permutation in ``perm_indices``.
+
+    The fallback for aggregations that are not a plain mean, and so have no closed-form accumulation.
+    Rows are gathered per label rather than by permuting the whole matrix, which selects the same rows in the same order at a fraction of the cost.
+    """
+    return np.array([[agg_fn(X[perm_idx[rows]], axis=0) for rows in label_rows] for perm_idx in perm_indices])
+
+
+def _chunk_permutations(
+    rng: np.random.Generator,
+    n_obs: int,
+    n_perms: int,
+    n_chunks: int,
+) -> Iterator[NDArray[np.integer]]:
+    """Draw ``n_perms`` shuffles of ``range(n_obs)``, yielded in blocks.
+
+    Lazily, so that peak memory is set by the block size rather than by ``n_perms``, and in the smallest integer type that fits ``n_obs``.
+    """
+    dtype = np.min_scalar_type(n_obs - 1)
+    idx = np.arange(n_obs)
+    for chunk in np.array_split(np.arange(n_perms), n_chunks):
+        yield np.array([rng.permutation(idx) for _ in chunk], dtype=dtype)
 
 
 def _generate_perms_cube(
@@ -105,58 +278,104 @@ def _generate_perms_cube(
     n_perms: int,
     labels_mask: NDArray[np.bool_],
     seed: int,
-    agg_fn: _AggFn,
+    aggregation: Aggregation,
     n_jobs: int,
     verbose: bool,
 ) -> NDArray[np.floating]:
-    # initialize rng
+    """Build the ``(n_perms, n_labels, n_genes)`` cube of per-label aggregates under the null.
+
+    Permutations are drawn in the same order whatever ``n_jobs`` is, so the cube -- and every p-value derived from it -- depends only on ``seed``.
+    They are also drawn, aggregated and written out a block at a time, so peak memory is set by the block size rather than by ``n_perms``.
+    """
     rng = np.random.default_rng(seed=seed)
+    n_labels = labels_mask.shape[1]
+    n_genes = X.shape[1]
+    label_rows = [np.flatnonzero(labels_mask[:, label]) for label in range(n_labels)]
+    counts = np.array([rows.size for rows in label_rows])
 
-    # indexes to be shuffled
-    idx = np.arange(X.shape[0])
+    csr = X if isinstance(X, csr_matrix | csr_array) else None
+    compiled = csr is not None and _kernel_applies(csr, aggregation)
 
-    # Perm should be a cube /w dims: n_perms x idents x n_genes
-    perms = np.zeros((n_perms, labels_mask.shape[1], X.shape[1]))
+    n_chunks = max(1, min(n_perms, -(-n_perms * X.shape[0] // _MAX_PERM_INDEX_ELEMENTS)))
+    if not compiled and n_jobs != 1:
+        n_chunks = max(n_chunks, min(n_perms, 4 * n_jobs))
+    chunks = _chunk_permutations(rng, X.shape[0], n_perms, n_chunks)
 
-    # Use Parallel to enable parallelization
-    results = Parallel(n_jobs=n_jobs)(
-        delayed(_permute_and_aggregate)(perm, rng.permutation(idx), X, labels_mask, agg_fn)
-        for perm in tqdm(range(n_perms), disable=not verbose)
-    )
+    results: Iterable[NDArray[np.floating]]
+    if csr is not None and compiled:
+        data, indices, indptr = _csr_buffers(csr)
+        if aggregation == "mean":
+            label_of_row = np.argmax(labels_mask, axis=1).astype(np.int64)
+            divisor = counts[None, :, None].astype(np.float64)
+            results = (
+                _perm_group_sums(data, indices, indptr, perm_indices, label_of_row, n_labels, n_genes) / divisor
+                for perm_indices in chunks
+            )
+        else:
+            order = np.concatenate(label_rows).astype(np.int64)
+            label_ptr = np.concatenate([[0], np.cumsum(counts)]).astype(np.int64)
+            results = (
+                _perm_group_trimeans(data, indices, indptr, perm_indices, order, label_ptr, n_genes)
+                for perm_indices in chunks
+            )
+    elif n_jobs == 1:
+        results = (
+            _permute_and_aggregate(perm_indices, X, label_rows, _AGG_FNS[aggregation]) for perm_indices in chunks
+        )
+    else:
+        results = Parallel(n_jobs=n_jobs, prefer="threads", return_as="generator")(
+            delayed(_permute_and_aggregate)(perm_indices, X, label_rows, _AGG_FNS[aggregation])
+            for perm_indices in chunks
+        )
 
-    # Unpack results
-    for perm, permuted_means in results:
-        perms[perm] = np.reshape(permuted_means, (labels_mask.shape[1], X.shape[1]))
+    perms = np.zeros((n_perms, n_labels, n_genes))
+    offset = 0
+    with _numba_threads(n_jobs) if compiled else nullcontext(), tqdm(total=n_perms, disable=not verbose) as bar:
+        for chunk_means in results:
+            n_chunk = chunk_means.shape[0]
+            perms[offset : offset + n_chunk] = np.reshape(chunk_means, (n_chunk, n_labels, n_genes))
+            offset += n_chunk
+            bar.update(n_chunk)
 
     return perms
 
 
-def _get_positions(
-    adata: AnnData,
-    lr_res: pd.DataFrame,
-) -> tuple[dict[str, int], dict[str, int], dict[str, int]]:
-    labels = get_obs(adata)["@label"].cat.categories
+def _csr_buffers(X: csr_matrix | csr_array) -> tuple[NDArray[np.floating], NDArray[np.integer], NDArray[np.integer]]:
+    """Hand the CSR triple to a kernel as plain arrays, which scipy types more loosely than it stores them."""
+    return np.asarray(X.data), np.asarray(X.indices), np.asarray(X.indptr)
 
-    # get positions of each entity in the matrix
-    ligand_pos = {entity: np.where(adata.var_names == entity)[0][0] for entity in lr_res["ligand"]}
-    receptor_pos = {entity: np.where(adata.var_names == entity)[0][0] for entity in lr_res["receptor"]}
-    labels_pos = {labels[pos]: pos for pos in range(labels.shape[0])}
 
-    return ligand_pos, receptor_pos, labels_pos
+def _kernel_applies(X: csr_matrix | csr_array, aggregation: Aggregation) -> bool:
+    """Say whether the compiled kernel for ``aggregation`` may be used on ``X``.
+
+    The trimean kernel treats every row that stored nothing for a gene as a zero that sorts below the stored entries, which a negative entry would violate.
+    """
+    return not (aggregation == "trimean" and X.data.size and np.asarray(X.data).min() < 0)
+
+
+def _index_of(index: pd.Index, values: pd.Series, what: str) -> NDArray[np.intp]:
+    """Locate ``values`` in ``index``, raising if any of them is absent.
+
+    :meth:`~pandas.Index.get_indexer` hashes the index once; the equivalent :func:`numpy.where` scan per value is quadratic in the number of interactions.
+    """
+    positions = index.get_indexer(pd.Index(values))
+    if (missing := positions == -1).any():
+        absent = pd.unique(pd.Series(values)[missing])
+        raise KeyError(f"{what}(s) absent from `adata.var_names`: {', '.join(map(str, absent))}.")
+    return np.asarray(positions, dtype=np.intp)
 
 
 def _get_mat_idx(
     adata: AnnData,
     lr_res: pd.DataFrame,
-) -> tuple[pd.Series, pd.Series, pd.Series, pd.Series]:
-    # convert to indexes
-    ligand_pos, receptor_pos, labels_pos = _get_positions(adata, lr_res)
+) -> tuple[NDArray[np.intp], NDArray[np.intp], NDArray[np.intp], NDArray[np.intp]]:
+    labels = get_obs(adata)["@label"].cat.categories
 
-    ligand_idx = lr_res["ligand"].map(ligand_pos)
-    receptor_idx = lr_res["receptor"].map(receptor_pos)
+    ligand_idx = _index_of(adata.var_names, lr_res["ligand"], "ligand")
+    receptor_idx = _index_of(adata.var_names, lr_res["receptor"], "receptor")
 
-    source_idx = lr_res["source"].map(labels_pos)
-    target_idx = lr_res["target"].map(labels_pos)
+    source_idx = _index_of(labels, lr_res["source"], "source label")
+    target_idx = _index_of(labels, lr_res["target"], "target label")
 
     return ligand_idx, receptor_idx, source_idx, target_idx
 
@@ -165,7 +384,6 @@ def _calculate_pvals(
     lr_truth: NDArray[np.floating],
     perm_stats: NDArray[np.floating] | None,
     _score_fn: _AggFn,
-    proximity_weights: NDArray[np.floating] | None = None,
 ) -> NDArray[np.floating] | None:
     """
     Calculate p-values for a given DataFrame x and permutation statistics
@@ -173,61 +391,36 @@ def _calculate_pvals(
     Parameters
     ----------
     lr_truth
-        Observed LR scores, shape (n_interactions,)
+        Observed LR scores, shape (n_interactions,). Already proximity-weighted when the
+        caller asked for spatial weighting.
     perm_stats
         Permutation statistics, shape (2, n_perms, n_interactions)
     _score_fn
         Function to combine ligand and receptor statistics
-    proximity_weights
-        Optional spatial proximity weights, shape (n_interactions,)
 
     Returns
     -------
     P-values for the observed scores
     """
-    # calculate p-values
-    if perm_stats is not None:
-        lr_perm_means = _score_fn(perm_stats, axis=0)
+    if perm_stats is None:
+        return None
 
-        # Apply proximity weights to both observed and permuted if provided
-        # Note: proximity weights, if any, are expected to have been applied
-        # to the observed scores (lr_truth) upstream. We also apply them
-        # to the permuted statistics here to maintain consistency in the
-        # null distribution when spatial structure is part of the signal.
-        if proximity_weights is not None:
-            # Weight permuted: (n_perms, n_interactions) * (n_interactions,)
-            # Broadcasting automatically handles dimension alignment
-            lr_perm_means = lr_perm_means * proximity_weights
+    lr_perm_means = _score_fn(perm_stats, axis=0)
+    n_perms = perm_stats.shape[1]
 
-        n_perms = perm_stats.shape[1]
-        pvals: NDArray[np.floating] | None = np.sum(np.greater_equal(lr_perm_means, lr_truth), axis=0) / n_perms
-    else:
-        pvals = None
-
-    return pvals
+    return np.asarray(np.sum(np.greater_equal(lr_perm_means, lr_truth), axis=0) / n_perms)
 
 
 def _apply_proximity_weights(
     observed_scores: NDArray[np.floating],
     x: pd.DataFrame,
-) -> tuple[NDArray[np.floating], NDArray[np.floating] | None]:
-    """
-    Extract proximity weights from DataFrame and apply to observed scores.
+) -> NDArray[np.floating]:
+    """Scale observed interaction scores by spatial proximity, where it was computed.
 
-    Parameters
-    ----------
-    observed_scores
-        Observed interaction scores, shape (n_interactions,)
-    x
-        DataFrame with LIANA results, may contain 'proximity' column
-
-    Returns
-    -------
-    Tuple of (weighted_scores, proximity_weights)
-        - weighted_scores: observed scores multiplied by proximity if present, otherwise unchanged
-        - proximity_weights: array of weights or None if not present
+    Only the observed statistic is weighted.
+    Weighting the permuted null by the same factor would cancel out of the comparison ``perm * w >= obs * w`` and leave every p-value unchanged, which is what made spatial weighting a no-op for the permutation-based methods.
+    Down-weighting only the observed side is what makes a distant pair need a correspondingly stronger expression signal to clear the null.
     """
-    proximity_weights = np.asarray(x["proximity"].to_numpy()) if "proximity" in x.columns else None
-    if proximity_weights is not None:
-        observed_scores = observed_scores * proximity_weights
-    return observed_scores, proximity_weights
+    if "proximity" not in x.columns:
+        return observed_scores
+    return observed_scores * np.asarray(x["proximity"].to_numpy())

--- a/src/liana/_core/_pipe_utils/_get_mean_perms.py
+++ b/src/liana/_core/_pipe_utils/_get_mean_perms.py
@@ -36,6 +36,12 @@ the return type is what callers rely on.
 type Aggregation = Literal["mean", "trimean"]
 """The location estimate a permutation-based method builds its null from."""
 
+_TIE_RTOL = 1e-6
+"""How close a permuted score has to be to the observed one to count as tied with it.
+
+An order of magnitude above the resolution of the `float32` the scores are stored in, and orders below any difference that carries signal.
+"""
+
 _MAX_PERM_INDEX_ELEMENTS = 1 << 24
 """Cap on how many row positions one block of permutations may hold, so that peak memory does not scale with ``n_perms``."""
 
@@ -408,7 +414,13 @@ def _calculate_pvals(
     lr_perm_means = _score_fn(perm_stats, axis=0)
     n_perms = perm_stats.shape[1]
 
-    return np.asarray(np.sum(np.greater_equal(lr_perm_means, lr_truth), axis=0) / n_perms)
+    # A permutation that leaves a cluster's membership unchanged -- the only possibility
+    # when a sample carries a single cluster -- has to score exactly as the observation
+    # does. The two sides are accumulated by different routines, so that tie survives only
+    # if it is compared within the tolerance of the single precision they are stored in.
+    exceeds = np.greater_equal(lr_perm_means, lr_truth) | np.isclose(lr_perm_means, lr_truth, rtol=_TIE_RTOL, atol=0.0)
+
+    return np.asarray(np.sum(exceeds, axis=0) / n_perms)
 
 
 def _apply_proximity_weights(

--- a/src/liana/_core/_pipe_utils/_pre.py
+++ b/src/liana/_core/_pipe_utils/_pre.py
@@ -220,16 +220,7 @@ def check_vars(var_names: Iterable[str], complex_sep: str | None, verbose: bool 
         Separator or any substring to check for in the variable names
     %(verbose)s
     """
-    var_issues = []
-    if complex_sep is not None:
-        for name in var_names:
-            if complex_sep in name:
-                var_issues.append(name)
-    else:
-        pass
-
-    # XXX: Achieves the same but faster:
-    # var_issues = [] if complex_sep is None else [i for i in var_names if complex_sep in i]
+    var_issues = [] if complex_sep is None else [name for name in var_names if complex_sep in name]
 
     _logg(
         f"{var_issues} contain `{complex_sep}`. Consider replacing those!",

--- a/src/liana/datasets/datasets.py
+++ b/src/liana/datasets/datasets.py
@@ -56,7 +56,6 @@ def kang_2018() -> AnnData:
         "Dendritic cells": "DCs",
         "Megakaryocytes": "Mega",
     }
-    # `cell_type` is categorical, and replacing its categories one by one is an error in pandas >=3
     obs["cell_abbr"] = obs["cell_type"].astype(str).replace(abbreviations).astype("category")
 
     return adata

--- a/src/liana/datasets/datasets.py
+++ b/src/liana/datasets/datasets.py
@@ -56,7 +56,8 @@ def kang_2018() -> AnnData:
         "Dendritic cells": "DCs",
         "Megakaryocytes": "Mega",
     }
-    obs["cell_abbr"] = obs["cell_type"].replace(abbreviations)
+    # `cell_type` is categorical, and replacing its categories one by one is an error in pandas >=3
+    obs["cell_abbr"] = obs["cell_type"].astype(str).replace(abbreviations).astype("category")
 
     return adata
 

--- a/src/liana/method/sc/_Method.py
+++ b/src/liana/method/sc/_Method.py
@@ -330,7 +330,7 @@ class Method(MethodMeta):
             base=base,
             de_method=de_method,
             verbose=verbose,
-            _score=self._method,
+            score=self._method,
             n_perms=n_perms,
             seed=seed,
             n_jobs=n_jobs,
@@ -340,9 +340,6 @@ class Method(MethodMeta):
             spatial_kwargs=spatial_kwargs,
             mdata_kwargs=mdata_kwargs,
         )
-        if not isinstance(liana_res, DataFrame):  # only the consensus path returns a dict
-            raise TypeError(f"Expected a DataFrame of results, got {type(liana_res).__name__}.")
-
         if inplace:
             adata.uns[key_added] = liana_res
         return None if inplace else liana_res

--- a/src/liana/method/sc/_cellchat.py
+++ b/src/liana/method/sc/_cellchat.py
@@ -39,8 +39,8 @@ def _cellchat_score(
     A tuple with lr_mean and pvalue for x
     """
     lr_prob = _lr_probability((x["ligand_trimean"].to_numpy(), x["receptor_trimean"].to_numpy()))
-    lr_prob, proximity_weights = _apply_proximity_weights(lr_prob, x)
-    cellchat_pvals = _calculate_pvals(lr_prob, perm_stats, _lr_probability, proximity_weights)
+    lr_prob = _apply_proximity_weights(lr_prob, x)
+    cellchat_pvals = _calculate_pvals(lr_prob, perm_stats, _lr_probability)
 
     return lr_prob, cellchat_pvals
 

--- a/src/liana/method/sc/_cellphonedb.py
+++ b/src/liana/method/sc/_cellphonedb.py
@@ -35,8 +35,8 @@ def _cpdb_score(
     zero_msk = (x["ligand_means"] == 0) | (x["receptor_means"] == 0)
     lr_means = _mean((x["ligand_means"].to_numpy(), x["receptor_means"].to_numpy()))
     lr_means[zero_msk] = 0
-    lr_means, proximity_weights = _apply_proximity_weights(lr_means, x)
-    cpdb_pvals = _calculate_pvals(lr_means, perm_stats, _mean, proximity_weights)
+    lr_means = _apply_proximity_weights(lr_means, x)
+    cpdb_pvals = _calculate_pvals(lr_means, perm_stats, _mean)
 
     return lr_means, cpdb_pvals
 

--- a/src/liana/method/sc/_geometric_mean.py
+++ b/src/liana/method/sc/_geometric_mean.py
@@ -26,9 +26,9 @@ def _gmean_score(
     A tuple with lr_mean and p-value for x
     """
     lr_gmeans = np.asarray(gmean((x["ligand_means"].to_numpy(), x["receptor_means"].to_numpy()), axis=0))
-    weighted, proximity_weights = _apply_proximity_weights(lr_gmeans, x)
+    weighted = _apply_proximity_weights(lr_gmeans, x)
 
-    gmean_pvals = _calculate_pvals(weighted, perm_stats, gmean, proximity_weights)
+    gmean_pvals = _calculate_pvals(weighted, perm_stats, gmean)
 
     return weighted, gmean_pvals
 

--- a/src/liana/method/sc/_liana_pipe.py
+++ b/src/liana/method/sc/_liana_pipe.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from functools import reduce
 from typing import TYPE_CHECKING, Literal, TypedDict
 
 import numpy as np
@@ -9,7 +8,6 @@ import pandas as pd
 import scanpy as sc
 from anndata import AnnData
 from mudata import MuData
-from scipy.sparse import csr_matrix
 from scipy.stats import norm
 
 from liana._core._constants import CommonColumns as C
@@ -21,7 +19,7 @@ from liana._core._docs import d
 from liana._core._pipe_utils import assert_covered, filter_resource, prep_check_adata
 from liana._core._pipe_utils._aggregate import _aggregate
 from liana._core._pipe_utils._common import _get_groupby_subset, _get_props, _join_stats
-from liana._core._pipe_utils._get_mean_perms import _AggFn, _get_mat_idx, _get_means_perms
+from liana._core._pipe_utils._get_mean_perms import Aggregation, _get_mat_idx, _get_means_perms, _trimean
 from liana._core._pipe_utils._pre import _choose_mtx_rep
 from liana._core._types import get_obs, get_x
 from liana.multisample.mdata_to_anndata import mdata_to_anndata
@@ -30,10 +28,15 @@ from liana.resource._reassemble_complexes import _explode_complexes, _filter_rea
 from liana.resource.select_resource import _handle_resource
 
 if TYPE_CHECKING:
-    from collections.abc import Callable, Sequence
+    from collections.abc import Callable
 
     from liana._core._types import MatrixLike
     from liana.method.sc._Method import MethodMeta
+    from liana.method.sc._rank_aggregate import AggregateClass
+
+
+_SUBUNIT_COLS: list[str] = [P.ligand, P.receptor, C.ligand_props, C.receptor_props]
+"""Per-subunit columns every method needs to reassemble complexes."""
 
 
 class MdataKwargs(TypedDict, total=False):
@@ -60,35 +63,27 @@ class SpatialKwargs(TypedDict, total=False):
 
 
 @d.dedent
-def liana_pipe(
+def _prepare_lr_stats(
     adata: AnnData | MuData,
     groupby: str,
     resource_name: str,
     resource: pd.DataFrame | None,
     interactions: list[tuple[str, str]] | None,
     groupby_pairs: pd.DataFrame | None,
-    expr_prop: float,
     min_cells: int,
     base: float,
     de_method: DeMethod,
-    n_perms: int | None,
-    seed: int,
     verbose: bool,
     use_raw: bool,
-    n_jobs: int,
     layer: str | None,
-    supp_columns: list[str] | None = None,
-    return_all_lrs: bool = False,
-    spatial_key: str | None = None,
-    spatial_kwargs: SpatialKwargs | None = None,
-    _score: MethodMeta | None = None,
-    _methods: Sequence[MethodMeta] | None = None,
-    _consensus_opts: list[str] | Literal[False] | None = None,
-    _aggregate_method: Literal["rra", "mean"] = "rra",
-    mdata_kwargs: MdataKwargs | None = None,
-) -> pd.DataFrame | dict[str, pd.DataFrame]:
+    complex_cols: list[str],
+    add_cols: list[str],
+    spatial_key: str | None,
+    spatial_kwargs: SpatialKwargs | None,
+    mdata_kwargs: MdataKwargs,
+) -> tuple[AnnData, pd.DataFrame]:
     """
-    Single-cell Ligand-receptor inference pipeline.
+    Assemble the per-cluster ligand and receptor statistics every method scores from.
 
     Parameters
     ----------
@@ -98,56 +93,25 @@ def liana_pipe(
     %(resource)s
     %(interactions)s
     %(groupby_pairs)s
-    %(expr_prop)s
     %(min_cells)s
     %(base)s
     %(de_method)s
-    %(n_perms_sc)s
-    %(seed)s
     %(verbose)s
     %(use_raw)s
     %(layer)s
-    supp_columns
-        Additional columns to be added to the output of each method.
-    %(return_all_lrs)s
-    _score
-        Instance of Method classes (None by default - returns LR stats - no methods used).
-    _methods
-        Methods to be run (only relevant for consensus).
-    _consensus_opts
-        Ways to aggregate interactions across methods by default does all aggregations (['Specificity', 'Magnitude']).
-    _aggregate_method
-        RobustRankAggregate('rra') or mean rank ('mean').
+    complex_cols
+        Columns relevant for protein complexes.
+    add_cols
+        Additional columns the scoring methods require.
     %(spatial_key)s
     %(spatial_kwargs)s
     %(mdata_kwargs)s
 
     Returns
     -------
-    A DataFrame with ligand-receptor results
+    The prepared :class:`~anndata.AnnData` and a DataFrame of one row per ligand-receptor
+    subunit and cluster pair.
     """
-    if mdata_kwargs is None:
-        mdata_kwargs = MdataKwargs()
-
-    _key_cols = P.primary
-
-    if _score is not None:
-        _complex_cols, _add_cols = _score.complex_cols, _score.add_cols
-    else:
-        _complex_cols = [C.ligand_means, C.receptor_means]
-        _add_cols = M.get_all_values()
-
-    if n_perms is None:
-        _consensus_opts = ["Magnitude"]
-
-    if supp_columns is None:
-        supp_columns = []
-    _add_cols = _add_cols + [P.ligand, P.receptor, C.ligand_props, C.receptor_props] + supp_columns
-
-    # initialize mat_mean for sca
-    mat_mean = None
-    mat_max = None
-
     resource = _handle_resource(
         interactions=interactions, resource=resource, resource_name=resource_name, verbose=verbose
     )
@@ -172,12 +136,8 @@ def liana_pipe(
         verbose=verbose,
     )
 
-    if M.mat_mean in _add_cols:
-        mat_mean = np.float32(get_x(adata).mean(dtype="float32"))
-
-    # get mat max for CellChat
-    if M.mat_max in _add_cols:
-        mat_max = np.float32(get_x(adata).max())
+    mat_mean = np.float32(get_x(adata).mean(dtype="float32")) if M.mat_mean in add_cols else None
+    mat_max = np.float32(get_x(adata).max()) if M.mat_max in add_cols else None
 
     # Check overlap between resource and adata
     assert_covered(
@@ -188,7 +148,7 @@ def liana_pipe(
     resource = filter_resource(resource, adata.var_names)
 
     # Cluster stats
-    if (M.ligand_cdf in _add_cols) or (M.receptor_cdf in _add_cols):
+    if (M.ligand_cdf in add_cols) or (M.receptor_cdf in add_cols):
         cluster_stats = _cluster_stats(adata)
 
     # Create Entities
@@ -199,128 +159,311 @@ def liana_pipe(
     if verbose:
         print(f"Generating ligand-receptor stats for {adata.shape[0]} samples and {adata.shape[1]} features")
 
-    # Get lr results
     lr_res = _get_lr(
         adata=adata,
         resource=resource,
         groupby_pairs=groupby_pairs,
         mat_mean=mat_mean,
         mat_max=mat_max,
-        relevant_cols=_key_cols + _add_cols + _complex_cols,
+        relevant_cols=P.primary + add_cols + complex_cols,
         de_method=de_method,
         base=base,
         verbose=verbose,
     )
 
     # Ligand and receptor score based on unfiltered cluster mean and cluster std. Handles protein complexes
-    if (M.ligand_cdf in _add_cols) or (M.receptor_cdf in _add_cols):
+    if (M.ligand_cdf in add_cols) or (M.receptor_cdf in add_cols):
         lr_res = _complex_score(lr_res, cluster_stats)
 
     # Mean Sums required for NATMI (note done on subunits also)
-    if M.ligand_means_sums in _add_cols:
+    if M.ligand_means_sums in add_cols:
         on = [x for x in P.complete if x != P.source]
         lr_res = _sum_means(lr_res, what=C.ligand_means, on=on)
-    if M.receptor_means_sums in _add_cols:
+    if M.receptor_means_sums in add_cols:
         on = [x for x in P.complete if x != P.target]
         lr_res = _sum_means(lr_res, what=C.receptor_means, on=on)
 
-    # Weight by spatial proximity when requested
     if spatial_key is not None:
-        if spatial_key not in adata.obsm:
-            raise KeyError(f"`spatial_key` {spatial_key!r} not found in `adata.obsm`.")
-        if spatial_kwargs is None:
-            spatial_kwargs = SpatialKwargs()
-
-        proximity_df = spatial_pair_proximity(
-            adata=adata, groupby="@label", spatial_key=spatial_key, verbose=verbose, **spatial_kwargs
+        lr_res = _add_proximity(
+            lr_res, adata=adata, spatial_key=spatial_key, spatial_kwargs=spatial_kwargs, verbose=verbose
         )
-        # Set interacting to 0 where not interacting
-        # Note: this sets proximity to 0 for non-interacting pairs (according to the count/interaction
-        # threshold used inside spatial_pair_proximity), so the resulting "proximity" column reflects
-        # both spatial closeness AND interaction/count-based significance rather than pure distance.
-        proximity_df["proximity"] = proximity_df["proximity"] * proximity_df["interacting"]
 
-        lr_res = lr_res.merge(proximity_df[["source", "target", "proximity"]], on=["source", "target"], how="left")
-        lr_res["proximity"] = lr_res["proximity"].fillna(0.0)
+    return adata, lr_res
 
-    # Calculate Score
-    if _score is not None:
-        if _score.method_name == "Rank_Aggregate":
-            # Run all methods in consensus
-            lrs: dict[str, pd.DataFrame] = {}
-            if _methods is None:
-                raise ValueError("`_methods` must be provided for the consensus method.")
-            for method in _methods:
-                if verbose:
-                    print(f"Running {method.method_name}")
 
-                lrs[method.method_name] = _run_method(
-                    lr_res=lr_res.copy(),
-                    adata=adata,
-                    groupby=groupby,
-                    expr_prop=expr_prop,
-                    _score=method,
-                    _key_cols=_key_cols,
-                    _complex_cols=method.complex_cols,
-                    _add_cols=method.add_cols,
-                    n_perms=n_perms,
-                    seed=seed,
-                    return_all_lrs=return_all_lrs,
-                    n_jobs=n_jobs,
-                    verbose=verbose,
-                    _aggregate_flag=True,
-                )
-            if _consensus_opts is False:  # Return by method results as they are
-                return lrs
-            # local import: `_rank_aggregate` imports this module
-            from liana.method.sc._rank_aggregate import AggregateClass
+def _add_proximity(
+    lr_res: pd.DataFrame,
+    adata: AnnData,
+    spatial_key: str,
+    spatial_kwargs: SpatialKwargs | None,
+    verbose: bool,
+) -> pd.DataFrame:
+    """Attach a per-cluster-pair spatial proximity weight to ``lr_res``.
 
-            if not isinstance(_score, AggregateClass):
-                raise TypeError("Aggregation requires an `AggregateClass` score.")
-            lr_res = _aggregate(
-                lrs,
-                consensus=_score,
-                aggregate_method=_aggregate_method,
-                _key_cols=_key_cols,
-                _consensus_opts=_consensus_opts,
-            )
-        else:  # Run the specific method in mind
-            lr_res = _run_method(
-                lr_res=lr_res,
-                adata=adata,
-                groupby=groupby,
-                expr_prop=expr_prop,
-                _score=_score,
-                _key_cols=_key_cols,
-                _complex_cols=_complex_cols,
-                _add_cols=_add_cols,
-                n_perms=n_perms,
-                return_all_lrs=return_all_lrs,
-                n_jobs=n_jobs,
-                verbose=verbose,
-                seed=seed,
-            )
-    else:  # Just return lr_res
-        lr_res = _filter_reassemble_complexes(
+    The weight is zeroed for pairs that `spatial_pair_proximity` did not find in contact, so it both masks cluster pairs that never meet and grades the ones that do.
+    """
+    if spatial_key not in adata.obsm:
+        raise KeyError(f"`spatial_key` {spatial_key!r} not found in `adata.obsm`.")
+
+    proximity_df = spatial_pair_proximity(
+        adata=adata, groupby=I.label, spatial_key=spatial_key, verbose=verbose, **(spatial_kwargs or SpatialKwargs())
+    )
+    proximity_df[C.proximity] = proximity_df[C.proximity] * proximity_df["interacting"]
+
+    lr_res = lr_res.merge(proximity_df[[P.source, P.target, C.proximity]], on=[P.source, P.target], how="left")
+    lr_res[C.proximity] = lr_res[C.proximity].fillna(0.0)
+
+    return lr_res
+
+
+@d.dedent
+def liana_pipe(
+    adata: AnnData | MuData,
+    groupby: str,
+    resource_name: str,
+    resource: pd.DataFrame | None,
+    interactions: list[tuple[str, str]] | None,
+    groupby_pairs: pd.DataFrame | None,
+    expr_prop: float,
+    min_cells: int,
+    base: float,
+    de_method: DeMethod,
+    n_perms: int | None,
+    seed: int,
+    verbose: bool,
+    use_raw: bool,
+    n_jobs: int,
+    layer: str | None,
+    score: MethodMeta | None = None,
+    supp_columns: list[str] | None = None,
+    return_all_lrs: bool = False,
+    spatial_key: str | None = None,
+    spatial_kwargs: SpatialKwargs | None = None,
+    mdata_kwargs: MdataKwargs | None = None,
+) -> pd.DataFrame:
+    """
+    Single-cell Ligand-receptor inference pipeline.
+
+    Parameters
+    ----------
+    %(adata)s
+    %(groupby)s
+    %(resource_name)s
+    %(resource)s
+    %(interactions)s
+    %(groupby_pairs)s
+    %(expr_prop)s
+    %(min_cells)s
+    %(base)s
+    %(de_method)s
+    %(n_perms_sc)s
+    %(seed)s
+    %(verbose)s
+    %(use_raw)s
+    %(layer)s
+    score
+        The method to score the interactions with. `None` returns the ligand-receptor
+        statistics without scoring them.
+    supp_columns
+        Additional columns to be added to the output of each method.
+    %(return_all_lrs)s
+    %(spatial_key)s
+    %(spatial_kwargs)s
+    %(mdata_kwargs)s
+
+    Returns
+    -------
+    A DataFrame with ligand-receptor results
+    """
+    complex_cols = score.complex_cols if score is not None else [C.ligand_means, C.receptor_means]
+    add_cols = (score.add_cols if score is not None else M.get_all_values()) + _SUBUNIT_COLS + (supp_columns or [])
+
+    adata, lr_res = _prepare_lr_stats(
+        adata=adata,
+        groupby=groupby,
+        resource_name=resource_name,
+        resource=resource,
+        interactions=interactions,
+        groupby_pairs=groupby_pairs,
+        min_cells=min_cells,
+        base=base,
+        de_method=de_method,
+        verbose=verbose,
+        use_raw=use_raw,
+        layer=layer,
+        complex_cols=complex_cols,
+        add_cols=add_cols,
+        spatial_key=spatial_key,
+        spatial_kwargs=spatial_kwargs,
+        mdata_kwargs=mdata_kwargs or MdataKwargs(),
+    )
+
+    if score is None:
+        return _filter_reassemble_complexes(
             lr_res=lr_res,
-            _key_cols=_key_cols,
+            _key_cols=P.primary,
             expr_prop=expr_prop,
-            complex_cols=_complex_cols,
+            complex_cols=complex_cols,
             return_all_lrs=return_all_lrs,
         )
 
-    if _score is not None:
-        orderby, ascending = (
-            (_score.magnitude, _score.magnitude_ascending)
-            if _score.magnitude is not None
-            else (_score.specificity, _score.specificity_ascending)
+    lr_res = _run_method(
+        lr_res=lr_res,
+        adata=adata,
+        groupby=groupby,
+        expr_prop=expr_prop,
+        _score=score,
+        _key_cols=P.primary,
+        _complex_cols=complex_cols,
+        _add_cols=add_cols,
+        n_perms=n_perms,
+        seed=seed,
+        return_all_lrs=return_all_lrs,
+        n_jobs=n_jobs,
+        verbose=verbose,
+    )
+
+    return _sort_by_score(lr_res, score)
+
+
+@d.dedent
+def liana_pipe_consensus(
+    adata: AnnData | MuData,
+    groupby: str,
+    resource_name: str,
+    resource: pd.DataFrame | None,
+    interactions: list[tuple[str, str]] | None,
+    groupby_pairs: pd.DataFrame | None,
+    expr_prop: float,
+    min_cells: int,
+    base: float,
+    de_method: DeMethod,
+    n_perms: int | None,
+    seed: int,
+    verbose: bool,
+    use_raw: bool,
+    n_jobs: int,
+    layer: str | None,
+    consensus: AggregateClass,
+    consensus_opts: list[str] | Literal[False] | None = None,
+    aggregate_method: Literal["rra", "mean"] = "rra",
+    return_all_lrs: bool = False,
+    spatial_key: str | None = None,
+    spatial_kwargs: SpatialKwargs | None = None,
+    mdata_kwargs: MdataKwargs | None = None,
+) -> pd.DataFrame | dict[str, pd.DataFrame]:
+    """
+    Run several ligand-receptor methods over one set of statistics and aggregate their ranks.
+
+    The ligand-receptor statistics are assembled once and re-scored by each method, so the
+    methods differ only in how they score, not in what they see.
+
+    Parameters
+    ----------
+    %(adata)s
+    %(groupby)s
+    %(resource_name)s
+    %(resource)s
+    %(interactions)s
+    %(groupby_pairs)s
+    %(expr_prop)s
+    %(min_cells)s
+    %(base)s
+    %(de_method)s
+    %(n_perms_sc)s
+    %(seed)s
+    %(verbose)s
+    %(use_raw)s
+    %(layer)s
+    consensus
+        The aggregation to combine the methods' ranks with.
+    consensus_opts
+        Ways to aggregate interactions across methods; by default both `'Specificity'`
+        and `'Magnitude'`. `False` returns each method's results untouched.
+    aggregate_method
+        RobustRankAggregate (`'rra'`) or mean rank (`'mean'`).
+    %(return_all_lrs)s
+    %(spatial_key)s
+    %(spatial_kwargs)s
+    %(mdata_kwargs)s
+
+    Returns
+    -------
+    A DataFrame of aggregated ligand-receptor results, or -- when `consensus_opts` is
+    `False` -- a DataFrame per method, keyed by method name.
+    """
+    if n_perms is None:
+        consensus_opts = ["Magnitude"]
+
+    add_cols = consensus.add_cols + _SUBUNIT_COLS
+
+    adata, lr_res = _prepare_lr_stats(
+        adata=adata,
+        groupby=groupby,
+        resource_name=resource_name,
+        resource=resource,
+        interactions=interactions,
+        groupby_pairs=groupby_pairs,
+        min_cells=min_cells,
+        base=base,
+        de_method=de_method,
+        verbose=verbose,
+        use_raw=use_raw,
+        layer=layer,
+        complex_cols=consensus.complex_cols,
+        add_cols=add_cols,
+        spatial_key=spatial_key,
+        spatial_kwargs=spatial_kwargs,
+        mdata_kwargs=mdata_kwargs or MdataKwargs(),
+    )
+
+    lrs: dict[str, pd.DataFrame] = {}
+    for method in consensus.methods:
+        if verbose:
+            print(f"Running {method.method_name}")
+
+        lrs[method.method_name] = _run_method(
+            lr_res=lr_res.copy(),
+            adata=adata,
+            groupby=groupby,
+            expr_prop=expr_prop,
+            _score=method,
+            _key_cols=P.primary,
+            _complex_cols=method.complex_cols,
+            _add_cols=method.add_cols,
+            n_perms=n_perms,
+            seed=seed,
+            return_all_lrs=return_all_lrs,
+            n_jobs=n_jobs,
+            verbose=verbose,
+            _aggregate_flag=True,
         )
-        if orderby is None:
-            raise ValueError(f"`{_score.method_name}` reports neither a magnitude nor a specificity score.")
 
-        lr_res = lr_res.sort_values(by=orderby, ascending=bool(ascending))
+    if consensus_opts is False:
+        return lrs
 
-    return lr_res
+    aggregated = _aggregate(
+        lrs,
+        consensus=consensus,
+        aggregate_method=aggregate_method,
+        _key_cols=P.primary,
+        _consensus_opts=consensus_opts,
+    )
+
+    return _sort_by_score(aggregated, consensus)
+
+
+def _sort_by_score(lr_res: pd.DataFrame, score: MethodMeta) -> pd.DataFrame:
+    """Order the results by the method's magnitude, falling back to its specificity."""
+    orderby, ascending = (
+        (score.magnitude, score.magnitude_ascending)
+        if score.magnitude is not None
+        else (score.specificity, score.specificity_ascending)
+    )
+    if orderby is None:
+        raise ValueError(f"`{score.method_name}` reports neither a magnitude nor a specificity score.")
+
+    return lr_res.sort_values(by=orderby, ascending=bool(ascending))
 
 
 def _get_lr(
@@ -475,11 +618,10 @@ def _run_method(
     )
 
     _add_cols = _add_cols + [P.ligand, P.receptor]
-    relevant_cols = reduce(lambda left, right: list(np.union1d(left, right)), [_key_cols, _complex_cols, _add_cols])
+    relevant_cols = list(np.union1d(np.union1d(_key_cols, _complex_cols), _add_cols))
 
-    # Preserve proximity column if present
-    if "proximity" in lr_res.columns:
-        relevant_cols = list(relevant_cols) + ["proximity"]
+    if C.proximity in lr_res.columns:
+        relevant_cols = list(relevant_cols) + [C.proximity]
 
     if return_all_lrs:
         relevant_cols = list(relevant_cols) + [I.lrs_to_keep]
@@ -489,16 +631,14 @@ def _run_method(
         lr_res = lr_res[lr_res[I.lrs_to_keep]]
     lr_res = lr_res[relevant_cols]
 
-    # Extract proximity weights if present in lr_res
-    proximity_weights = np.asarray(lr_res["proximity"].to_numpy()) if "proximity" in lr_res.columns else None
+    proximity_weights = np.asarray(lr_res[C.proximity].to_numpy()) if C.proximity in lr_res.columns else None
 
-    if (M.mat_max in _add_cols) & (_score.method_name == "CellChat"):
-        # CellChat matrix_max
+    if M.ligand_trimean in _complex_cols:
         norm_factor = np.unique(lr_res[M.mat_max].to_numpy())[0]
-        agg_fn: _AggFn = _trimean  # Calculate sparse matrix quantiles?
+        aggregation: Aggregation = "trimean"
     else:
         norm_factor = None
-        agg_fn = np.mean  # NOTE: change to sparse matrix mean?
+        aggregation = "mean"
 
     if _score.fun is None:
         raise ValueError(f"`{_score.method_name}` has no scoring function.")
@@ -510,7 +650,7 @@ def _run_method(
                 adata=adata,
                 n_perms=n_perms,
                 seed=seed,
-                agg_fn=agg_fn,
+                aggregation=aggregation,
                 norm_factor=norm_factor,
                 n_jobs=n_jobs,
                 verbose=verbose,
@@ -558,23 +698,14 @@ def _run_method(
         if lr_res[_score.specificity].isna().all():
             lr_res = lr_res.drop(_score.specificity, axis=1)
 
-    # Remove proximity column if present (internal use only)
-    if "proximity" in lr_res.columns:
-        lr_res = lr_res.drop("proximity", axis=1)
+    if C.proximity in lr_res.columns:
+        lr_res = lr_res.drop(C.proximity, axis=1)
 
     return lr_res
 
 
 def _assign_min_or_max(x: pd.Series, x_ascending: bool | None) -> float:
     return float(np.max(x) if x_ascending else np.min(x))
-
-
-def _trimean(a: csr_matrix, axis: int = 0) -> np.ndarray:
-    """Tukey's trimean, the location estimate CellChat scores with."""
-    dense = a.toarray()
-    quantiles = np.quantile(dense, q=[0.25, 0.75], axis=axis)
-    median = np.median(dense, axis=axis)
-    return np.asarray((quantiles[0] + 2 * median + quantiles[1]) / 4)
 
 
 def _cluster_stats(adata: AnnData) -> pd.DataFrame:

--- a/src/liana/method/sc/_rank_aggregate.py
+++ b/src/liana/method/sc/_rank_aggregate.py
@@ -10,7 +10,7 @@ from liana._core._constants import DefaultValues as V
 from liana._core._constants import DeMethod
 from liana._core._constants import Keys as K
 from liana._core._docs import d
-from liana.method.sc._liana_pipe import MdataKwargs, SpatialKwargs, liana_pipe
+from liana.method.sc._liana_pipe import MdataKwargs, SpatialKwargs, liana_pipe_consensus
 from liana.method.sc._Method import Method, MethodMeta
 
 
@@ -166,7 +166,7 @@ class AggregateClass(MethodMeta):
         """
         if mdata_kwargs is None:
             mdata_kwargs = {}
-        liana_res = liana_pipe(
+        liana_res = liana_pipe_consensus(
             adata=adata,
             groupby=groupby,
             resource_name=resource_name,
@@ -179,15 +179,14 @@ class AggregateClass(MethodMeta):
             return_all_lrs=return_all_lrs,
             de_method=de_method,
             verbose=verbose,
-            _score=self,
+            consensus=self,
             use_raw=use_raw,
             layer=layer,
             n_perms=n_perms,
             seed=seed,
             n_jobs=n_jobs,
-            _methods=self.methods,
-            _aggregate_method=aggregate_method,
-            _consensus_opts=consensus_opts,
+            aggregate_method=aggregate_method,
+            consensus_opts=consensus_opts,
             spatial_key=spatial_key,
             spatial_kwargs=spatial_kwargs,
             mdata_kwargs=mdata_kwargs,

--- a/src/liana/method/sp/_LRIC.py
+++ b/src/liana/method/sp/_LRIC.py
@@ -2,8 +2,10 @@ from __future__ import annotations
 
 from collections.abc import Callable, Sequence
 from functools import partial
-from typing import Any, NamedTuple
+from typing import TYPE_CHECKING, Any, NamedTuple
+from warnings import warn
 
+import numba as nb
 import numpy as np
 import pandas as pd
 from anndata import AnnData
@@ -23,10 +25,14 @@ from liana._core._types import MatrixLike, get_obs, get_x
 from liana.method.sp._utils import _add_complexes_to_var
 from liana.resource.select_resource import _handle_resource
 
+if TYPE_CHECKING:
+    prange = range
+else:
+    prange = nb.prange
+
 type Transform = Callable[[np.ndarray], np.ndarray]
 """Rescales an expression matrix before ligand/receptor weights are formed."""
 
-_EDGE_BLOCK_ELEMS = 1 << 22
 _MIN_CELLS_FRAC = 0.01
 
 # ── helpers ───────────────────────────────────────────────────────────
@@ -301,39 +307,31 @@ def _select_pairs(
     return kept
 
 
-# weighted ligand–receptor sums for grouped edge segments
-# g -> group, one radius bin for a fixed sender→receiver cell-type pair.
-# p -> ligand–receptor pair.
-# i→j is a directed spatial edge.
+@nb.njit(parallel=True, cache=True)
 def _segment_weighted_sums(
     I_sorted: np.ndarray,
     J_sorted: np.ndarray,
     bounds: np.ndarray,
     WL: np.ndarray,
     WR: np.ndarray,
-    pair_chunk: int,
 ) -> np.ndarray:
     """``out[g, p] = sum_{(i, j) in group g} WL[i, p] * WR[j, p]``, shape ``(n_groups, n_pairs)``.
 
-    Edges must already be sorted by group key (with ``bounds`` from
-    :func:`_edge_group_bounds`) so that each group occupies a contiguous slice.
+    ``g`` is a group -- one radius bin for a fixed sender-to-receiver cell-type pair -- and ``p`` a ligand-receptor pair.
+    Edges must already be sorted by group key (with ``bounds`` from :func:`_edge_group_bounds`) so that each group occupies a contiguous slice.
+    Accumulating edge by edge keeps the whole reduction out of temporaries, so nothing has to be tiled to bound memory.
     """
-    n_groups = len(bounds) - 1
+    n_groups = bounds.size - 1
     n_pairs = WL.shape[1]
     out = np.zeros((n_groups, n_pairs), dtype=np.float64)
-    for p0 in range(0, n_pairs, pair_chunk):
-        p1 = min(p0 + pair_chunk, n_pairs)
-        WLc, WRc = WL[:, p0:p1], WR[:, p0:p1]
-        # cap the gathered block so peak memory is bounded by _EDGE_BLOCK_ELEMS
-        edge_block = max(1, _EDGE_BLOCK_ELEMS // (p1 - p0))
-        for g in range(n_groups):
-            lo, hi = int(bounds[g]), int(bounds[g + 1])
-            if hi <= lo:
-                continue
-            acc = out[g, p0:p1]
-            for e0 in range(lo, hi, edge_block):
-                e1 = min(e0 + edge_block, hi)
-                acc += (WLc[I_sorted[e0:e1]] * WRc[J_sorted[e0:e1]]).sum(axis=0, dtype=np.float64)
+
+    for g in prange(n_groups):
+        for edge in range(bounds[g], bounds[g + 1]):
+            i = I_sorted[edge]
+            j = J_sorted[edge]
+            for p in range(n_pairs):
+                out[g, p] += WL[i, p] * WR[j, p]
+
     return out
 
 
@@ -589,7 +587,7 @@ class LRIC:
         transform_fn: Callable[[np.ndarray], np.ndarray] | None = None,
         use_raw: bool = V.use_raw,
         layer: str | None = V.layer,
-        pair_chunk: int = 256,
+        pair_chunk: int | None = None,
         key_added: str = "lric",
         inplace: bool = V.inplace,
         verbose: bool = V.verbose,
@@ -657,9 +655,9 @@ class LRIC:
         %(use_raw)s
         %(layer)s
         pair_chunk
-            Number of LR pairs processed per chunk when accumulating the
-            weighted numerator; lower to reduce peak memory on very large
-            resources.
+            Deprecated and ignored. The weighted numerator is now accumulated
+            without materialising per-chunk temporaries, so there is nothing to
+            tune.
         %(key_added)s
         %(inplace)s
         %(verbose)s
@@ -734,6 +732,13 @@ class LRIC:
 
         assert_covered(np.union1d(resource["ligand"], resource["receptor"]), adata.var_names, verbose=verbose)
 
+        if pair_chunk is not None:
+            warn(
+                "`pair_chunk` is deprecated and ignored; the weighted numerator no longer chunks.",
+                FutureWarning,
+                stacklevel=2,
+            )
+
         sup = _build_support(adata, spatial_key, max_radius, radius_step, annulus_steps, extend_first_annulus)
         if groupby is None:
             res = self._agnostic(
@@ -743,7 +748,6 @@ class LRIC:
                 expr_prop=expr_prop,
                 lr_sep=lr_sep,
                 transform_fn=transform_fn,
-                pair_chunk=pair_chunk,
                 verbose=verbose,
             )
         else:
@@ -756,7 +760,6 @@ class LRIC:
                 expr_prop=expr_prop,
                 lr_sep=lr_sep,
                 transform_fn=transform_fn,
-                pair_chunk=pair_chunk,
                 verbose=verbose,
             )
 
@@ -773,7 +776,6 @@ class LRIC:
         expr_prop: float,
         lr_sep: str,
         transform_fn: Transform | None,
-        pair_chunk: int,
         verbose: bool,
     ) -> pd.DataFrame:
         """Cell-type-agnostic LRIC across all cells (self-pairs excluded).
@@ -797,7 +799,7 @@ class LRIC:
         # fine tiles, then get rolled up into the (possibly overlapping) output
         # annuli -- so every pair is counted identically on both sides
         I_sorted, J_sorted, bounds = _group_edges(sup, sup.bin_idx, sup.n_fine)
-        num = sup.roll(_segment_weighted_sums(I_sorted, J_sorted, bounds, WL, WR, pair_chunk))
+        num = sup.roll(_segment_weighted_sums(I_sorted, J_sorted, bounds, WL, WR))
 
         # closed-form null mean: T(b) * E[wL(i) wR(j)] over random distinct pairs
         S_L, S_R, cross = WL.sum(0), WR.sum(0), (WL * WR).sum(0)
@@ -829,7 +831,6 @@ class LRIC:
         expr_prop: float,
         lr_sep: str,
         transform_fn: Transform | None,
-        pair_chunk: int,
         verbose: bool,
     ) -> pd.DataFrame:
         """Cell-type pairwise ("ct") LRIC under the conditional (within-type) null.
@@ -903,7 +904,7 @@ class LRIC:
 
             g0 = (si * n_types + ri) * n_fine
             grp = bounds[g0 : g0 + n_fine + 1]
-            Num_SR = sup.roll(_segment_weighted_sums(I_sorted, J_sorted, grp, WL, WR, pair_chunk))
+            Num_SR = sup.roll(_segment_weighted_sums(I_sorted, J_sorted, grp, WL, WR))
             # edges per group == observed ordered S->R pair count per tile
             T_SR = sup.roll(np.diff(grp).astype(np.float64))
 

--- a/src/liana/method/sp/_LRIC.py
+++ b/src/liana/method/sp/_LRIC.py
@@ -12,6 +12,7 @@ from anndata import AnnData
 from numpy.typing import ArrayLike, NDArray
 from scipy.sparse import sparray, spmatrix
 from scipy.spatial import cKDTree
+from scverse_misc import Deprecation
 from tqdm import tqdm
 
 from liana._core._common import _logg
@@ -29,6 +30,12 @@ if TYPE_CHECKING:
     prange = range
 else:
     prange = nb.prange
+
+_PAIR_CHUNK_DEPRECATION = Deprecation(
+    "2.1", "The weighted numerator no longer holds per-chunk temporaries, so there is nothing to tune."
+)
+"""Why `lric`'s `pair_chunk` no longer does anything."""
+
 
 type Transform = Callable[[np.ndarray], np.ndarray]
 """Rescales an expression matrix before ligand/receptor weights are formed."""
@@ -655,9 +662,9 @@ class LRIC:
         %(use_raw)s
         %(layer)s
         pair_chunk
-            Deprecated and ignored. The weighted numerator is now accumulated
-            without materialising per-chunk temporaries, so there is nothing to
-            tune.
+            Deprecated since 2.1 and ignored. The weighted numerator is now
+            accumulated without materialising per-chunk temporaries, so there is
+            nothing to tune.
         %(key_added)s
         %(inplace)s
         %(verbose)s
@@ -733,8 +740,11 @@ class LRIC:
         assert_covered(np.union1d(resource["ligand"], resource["receptor"]), adata.var_names, verbose=verbose)
 
         if pair_chunk is not None:
+            # `scverse_misc.deprecated_arg` would fit here, but it retypes the method as a
+            # plain callable, so every `lric(adata, ...)` call site loses its `self` binding
+            # under a type checker.
             warn(
-                "`pair_chunk` is deprecated and ignored; the weighted numerator no longer chunks.",
+                f"The argument pair_chunk is deprecated and will be removed in the future. {_PAIR_CHUNK_DEPRECATION}",
                 FutureWarning,
                 stacklevel=2,
             )

--- a/src/liana/method/sp/_misty/_Misty.py
+++ b/src/liana/method/sp/_misty/_Misty.py
@@ -7,6 +7,7 @@ import numpy as np
 import pandas as pd
 from anndata import AnnData
 from fast_array_utils.conv import to_dense
+from fast_array_utils.types import CSBase
 from mudata import MuData
 from numpy.typing import NDArray
 from sklearn.linear_model import LinearRegression, RidgeCV
@@ -141,8 +142,10 @@ class MistyData(MuData):
             connectivities = view.obsp[f"{self.spatial_key}_connectivities"]
             view.layers["weighted"] = _to_matrix(connectivities @ X, what="weighted layer")
         else:
-            weights = np.asarray(view.obsm[f"{self.spatial_key}_connectivities"]).T
-            view.varm["weighted"] = np.asarray(weights @ X).T
+            # `np.asarray` on a sparse `obsm` gives a 0-d object array, which cannot be multiplied.
+            weights = _to_matrix(view.obsm[f"{self.spatial_key}_connectivities"], what="spatial connectivities").T
+            weighted = (weights @ X).T
+            view.varm["weighted"] = weighted.tocsr() if isinstance(weighted, CSBase) else np.asarray(weighted)
 
     def get_weighted_matrix(self, view_name: str, predictors: list[str] | None = None) -> MatrixLike:
         """

--- a/src/liana/method/sp/_misty/_Misty.py
+++ b/src/liana/method/sp/_misty/_Misty.py
@@ -142,7 +142,6 @@ class MistyData(MuData):
             connectivities = view.obsp[f"{self.spatial_key}_connectivities"]
             view.layers["weighted"] = _to_matrix(connectivities @ X, what="weighted layer")
         else:
-            # `np.asarray` on a sparse `obsm` gives a 0-d object array, which cannot be multiplied.
             weights = _to_matrix(view.obsm[f"{self.spatial_key}_connectivities"], what="spatial connectivities").T
             weighted = (weights @ X).T
             view.varm["weighted"] = weighted.tocsr() if isinstance(weighted, CSBase) else np.asarray(weighted)

--- a/src/liana/plotting/__init__.py
+++ b/src/liana/plotting/__init__.py
@@ -1,23 +1,49 @@
-from ._annulus import annulus_plot
-from ._circle_plot import circle_plot
+from typing import Any
+
+from ._annulus import annulus
+from ._circle_plot import circle
 from ._connectivity_plot import connectivity
 from ._dotplot import dotplot, dotplot_by_sample
 from ._feature_by_group import feature_by_group
-from ._lric_plot import lric_divergence_plot, lric_lineplot
-from ._misty_plots import contributions, interactions, target_metrics
+from ._lric_plot import lric_divergence, lric_lineplot
+from ._misty_plots import misty_contributions, misty_interactions, misty_target_metrics
 from ._tileplot import tileplot
 
 __all__ = [
-    "annulus_plot",
-    "circle_plot",
+    "annulus",
+    "circle",
     "connectivity",
-    "contributions",
     "dotplot",
     "dotplot_by_sample",
     "feature_by_group",
-    "interactions",
-    "lric_divergence_plot",
+    "lric_divergence",
     "lric_lineplot",
-    "target_metrics",
+    "misty_contributions",
+    "misty_interactions",
+    "misty_target_metrics",
     "tileplot",
 ]
+
+_RENAMED = {
+    "annulus_plot": "annulus",
+    "circle_plot": "circle",
+    "contributions": "misty_contributions",
+    "interactions": "misty_interactions",
+    "lric_divergence_plot": "lric_divergence",
+    "target_metrics": "misty_target_metrics",
+}
+"""The 2.0 names, mapped onto the ones that follow the module's convention.
+
+Plot functions are bare nouns, as in :mod:`scanpy.pl`, and carry the prefix of the method they belong to when they only apply to that method.
+"""
+
+
+def __getattr__(name: str) -> Any:
+    if (renamed := _RENAMED.get(name)) is None:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+    from warnings import warn
+
+    warn(f"`liana.pl.{name}` is deprecated; use `liana.pl.{renamed}` instead.", FutureWarning, stacklevel=2)
+
+    return globals()[renamed]

--- a/src/liana/plotting/__init__.py
+++ b/src/liana/plotting/__init__.py
@@ -1,4 +1,8 @@
-from typing import Any
+from collections.abc import Callable
+from functools import wraps
+from typing import Any, cast
+
+from scverse_misc import Deprecation, deprecated
 
 from ._annulus import annulus
 from ._circle_plot import circle
@@ -24,26 +28,32 @@ __all__ = [
     "tileplot",
 ]
 
-_RENAMED = {
-    "annulus_plot": "annulus",
-    "circle_plot": "circle",
-    "contributions": "misty_contributions",
-    "interactions": "misty_interactions",
-    "lric_divergence_plot": "lric_divergence",
-    "target_metrics": "misty_target_metrics",
-}
-"""The 2.0 names, mapped onto the ones that follow the module's convention.
+_RENAMED_IN = "2.1"
+"""The release that settled the plotting names.
 
 Plot functions are bare nouns, as in :mod:`scanpy.pl`, and carry the prefix of the method they belong to when they only apply to that method.
 """
 
 
-def __getattr__(name: str) -> Any:
-    if (renamed := _RENAMED.get(name)) is None:
-        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+def _renamed_to[F: Callable[..., Any]](current: F, old_name: str) -> F:
+    """Expose ``current`` under the ``old_name`` it went by before :data:`_RENAMED_IN`.
 
-    from warnings import warn
+    The alias carries the old name so that the warning names the function that was actually called, and it is a distinct object so that :func:`~warnings.deprecated` marks only the alias -- which also lets a type checker flag the old name without flagging the new one.
+    """
 
-    warn(f"`liana.pl.{name}` is deprecated; use `liana.pl.{renamed}` instead.", FutureWarning, stacklevel=2)
+    @wraps(current)
+    def alias(*args: Any, **kwargs: Any) -> Any:
+        return current(*args, **kwargs)
 
-    return globals()[renamed]
+    alias.__name__ = alias.__qualname__ = old_name
+    message = Deprecation(_RENAMED_IN, f"Use `liana.pl.{current.__name__}` instead.")
+
+    return cast("F", deprecated(message)(alias))
+
+
+annulus_plot = _renamed_to(annulus, "annulus_plot")
+circle_plot = _renamed_to(circle, "circle_plot")
+contributions = _renamed_to(misty_contributions, "contributions")
+interactions = _renamed_to(misty_interactions, "interactions")
+lric_divergence_plot = _renamed_to(lric_divergence, "lric_divergence_plot")
+target_metrics = _renamed_to(misty_target_metrics, "target_metrics")

--- a/src/liana/plotting/_annulus.py
+++ b/src/liana/plotting/_annulus.py
@@ -11,7 +11,7 @@ from liana._core._types import get_coordinates
 
 
 @d.dedent
-def annulus_plot(
+def annulus(
     adata: AnnData,
     spatial_key: str = K.spatial_key,
     radius_step: float = 20.0,
@@ -60,7 +60,7 @@ def annulus_plot(
 
     >>> import liana as li
     >>> adata = li.ds.generate_toy_spatial()
-    >>> li.pl.annulus_plot(adata, radius_step=200, n_rings=4)
+    >>> li.pl.annulus(adata, radius_step=200, n_rings=4)
     """
     if spatial_key not in adata.obsm:
         raise KeyError(f"'{spatial_key}' not found in adata.obsm.")

--- a/src/liana/plotting/_circle_plot.py
+++ b/src/liana/plotting/_circle_plot.py
@@ -137,7 +137,7 @@ def get_mask_df(
 
 
 @d.dedent
-def circle_plot(
+def circle(
     adata: sc.AnnData,
     uns_key: str = K.uns_key,
     liana_res: pd.DataFrame | None = None,
@@ -236,7 +236,7 @@ def circle_plot(
     >>> import liana as li
     >>> adata = li.ds.generate_toy_adata()
     >>> li.mt.rank_aggregate(adata, groupby="bulk_labels", n_perms=None)
-    >>> ax = li.pl.circle_plot(adata, groupby="bulk_labels")
+    >>> ax = li.pl.circle(adata, groupby="bulk_labels")
 
     With `pivot_mode='mean'` and a `score_key` the edges are weighted by that
     score's mean instead of by the number of interactions.

--- a/src/liana/plotting/_lric_plot.py
+++ b/src/liana/plotting/_lric_plot.py
@@ -127,7 +127,7 @@ def lric_lineplot(
 
 
 @d.dedent
-def lric_divergence_plot(
+def lric_divergence(
     adata: AnnData | None = None,
     uns_key: str = "lric",
     liana_res: pd.DataFrame | None = None,
@@ -181,7 +181,7 @@ def lric_divergence_plot(
     >>> import liana as li
     >>> adata = li.ds.generate_toy_spatial()
     >>> li.mt.cross_pcf(adata, groupby="bulk_labels", key_added="cross_pcf")
-    >>> p = li.pl.lric_divergence_plot(
+    >>> p = li.pl.lric_divergence(
     ...     adata,
     ...     "cross_pcf",
     ...     feature_a=dict(source="CD14+ Monocyte", target="CD34+"),

--- a/src/liana/plotting/_misty_plots.py
+++ b/src/liana/plotting/_misty_plots.py
@@ -11,7 +11,7 @@ from liana.method.sp._misty._Misty import MistyData
 
 
 @d.dedent
-def target_metrics(
+def misty_target_metrics(
     misty: MistyData | None = None,
     stat: str | None = None,
     target_metrics: pd.DataFrame | None = None,
@@ -62,7 +62,7 @@ def target_metrics(
     >>> adata = adata[:, adata.var_names[:5]].copy()
     >>> misty = li.mt.genericMistyData(intra=adata, bandwidth=200, set_diag=True)
     >>> misty(model=li.mt.sp.LinearModel)
-    >>> p = li.pl.target_metrics(misty, stat="gain_R2")
+    >>> p = li.pl.misty_target_metrics(misty, stat="gain_R2")
 
     Pass `aggregate_fn` (e.g. `numpy.mean`) to summarise a masked model's
     per-group rows into boxplots.
@@ -104,7 +104,7 @@ def target_metrics(
 
 
 @d.dedent
-def contributions(
+def misty_contributions(
     misty: MistyData | None = None,
     target_metrics: pd.DataFrame | None = None,
     view_names: list[str] | None = None,
@@ -147,7 +147,7 @@ def contributions(
     >>> adata = adata[:, adata.var_names[:5]].copy()
     >>> misty = li.mt.genericMistyData(intra=adata, bandwidth=200, set_diag=True)
     >>> misty(model=li.mt.sp.LinearModel)
-    >>> p = li.pl.contributions(misty)
+    >>> p = li.pl.misty_contributions(misty)
     """
     if target_metrics is not None:
         target_metrics = target_metrics.copy()
@@ -191,7 +191,7 @@ def contributions(
 
 
 @d.dedent
-def interactions(
+def misty_interactions(
     misty: MistyData | None = None,
     interactions: pd.DataFrame | None = None,
     view: str | None = None,
@@ -242,7 +242,7 @@ def interactions(
     >>> adata = adata[:, adata.var_names[:5]].copy()
     >>> misty = li.mt.genericMistyData(intra=adata, bandwidth=200, set_diag=True)
     >>> misty(model=li.mt.sp.LinearModel)
-    >>> p = li.pl.interactions(misty, view="intra")
+    >>> p = li.pl.misty_interactions(misty, view="intra")
 
     `misty.view_names` lists the views available -- here `'intra'`, `'juxta'` and
     `'para'`.

--- a/tests/method/sc/test_methods.py
+++ b/tests/method/sc/test_methods.py
@@ -243,3 +243,24 @@ def test_spatial_key_opt_in(toy_spatial: AnnData) -> None:
     assert not isclose(unweighted["lr_means"].sum(), weighted["lr_means"].sum())
     with pytest.raises(KeyError, match="not found in `adata.obsm`"):
         cellphonedb(toy_spatial, groupby="bulk_labels", n_perms=None, use_raw=True, spatial_key="missing")
+
+
+def test_spatial_key_weights_pvals(toy_spatial: AnnData) -> None:
+    """Proximity has to reach the p-values, not just the magnitudes.
+
+    Weighting the permuted null by the same factor as the observed score cancels out of
+    `perm * w >= obs * w`, which left every p-value untouched.
+    """
+    keys = ["source", "target", "ligand_complex", "receptor_complex"]
+
+    unweighted = cellphonedb(toy_spatial, groupby="bulk_labels", n_perms=50, use_raw=True, inplace=False)
+    weighted = cellphonedb(
+        toy_spatial, groupby="bulk_labels", n_perms=50, use_raw=True, inplace=False, spatial_key="spatial"
+    )
+    assert unweighted is not None and weighted is not None
+
+    merged = unweighted.merge(weighted, on=keys, suffixes=("_unweighted", "_weighted"))
+
+    assert not merged["cellphone_pvals_unweighted"].equals(merged["cellphone_pvals_weighted"])
+    # down-weighting the observed score alone can only make it harder to beat the null
+    assert (merged["cellphone_pvals_weighted"] >= merged["cellphone_pvals_unweighted"]).all()

--- a/tests/method/sp/test_LRIC.py
+++ b/tests/method/sp/test_LRIC.py
@@ -757,7 +757,7 @@ def test_lric_no_lr_pairs_raises(adata: AnnData) -> None:
 def test_pair_chunk_is_deprecated(adata: AnnData, resource: pd.DataFrame) -> None:
     expected = as_frame(lric(adata, resource=resource, inplace=False, **_KWARGS))
 
-    with pytest.warns(FutureWarning, match="`pair_chunk` is deprecated"):
+    with pytest.warns(FutureWarning, match="argument pair_chunk is deprecated"):
         got = as_frame(lric(adata, resource=resource, inplace=False, pair_chunk=8, **_KWARGS))
 
     pd.testing.assert_frame_equal(got, expected)

--- a/tests/method/sp/test_LRIC.py
+++ b/tests/method/sp/test_LRIC.py
@@ -752,3 +752,12 @@ def test_lric_no_lr_pairs_raises(adata: AnnData) -> None:
         lric(adata, resource=bad, inplace=False, verbose=False)
     with raises(ValueError, match="Please check if appropriate organism/ID type"):
         lric(adata, resource=bad, groupby="cell_type", inplace=False, verbose=False)
+
+
+def test_pair_chunk_is_deprecated(adata: AnnData, resource: pd.DataFrame) -> None:
+    expected = as_frame(lric(adata, resource=resource, inplace=False, **_KWARGS))
+
+    with pytest.warns(FutureWarning, match="`pair_chunk` is deprecated"):
+        got = as_frame(lric(adata, resource=resource, inplace=False, pair_chunk=8, **_KWARGS))
+
+    pd.testing.assert_frame_equal(got, expected)

--- a/tests/method/test_get_mean_perms.py
+++ b/tests/method/test_get_mean_perms.py
@@ -6,9 +6,7 @@ from anndata import AnnData
 from pandas import DataFrame, read_csv
 from tests._helpers import get_obs, get_raw_x, get_x
 
-from liana._core._pipe_utils._get_mean_perms import _get_means_perms, _get_positions
-from liana.method.sc._cellphonedb import _mean
-from liana.method.sc._liana_pipe import _trimean
+from liana._core._pipe_utils._get_mean_perms import _get_mat_idx, _get_means_perms
 
 
 @pytest.fixture
@@ -30,25 +28,47 @@ def all_defaults(data_dir: pathlib.Path) -> DataFrame:
 
 def test_perms(adata: AnnData) -> None:
     perms = _get_means_perms(
-        adata=adata, norm_factor=None, agg_fn=_mean, n_perms=100, seed=1337, n_jobs=1, verbose=False
+        adata=adata, norm_factor=None, aggregation="mean", n_perms=100, seed=1337, n_jobs=1, verbose=False
     )
 
     assert perms.shape == (100, 10, 765)
 
 
 def test_positions(adata: AnnData, all_defaults: DataFrame) -> None:
-    ligand_pos, receptor_pos, labels_pos = _get_positions(adata, all_defaults)
+    ligand_idx, receptor_idx, source_idx, target_idx = _get_mat_idx(adata, all_defaults)
 
-    assert ligand_pos["MIF"] == 740
-    assert receptor_pos["CD4"] == 465
-    assert labels_pos["Dendritic"] == 9
+    labels = get_obs(adata)["@label"].cat.categories
+
+    assert set(ligand_idx[all_defaults["ligand"] == "MIF"]) == {740}
+    assert set(receptor_idx[all_defaults["receptor"] == "CD4"]) == {465}
+    assert set(source_idx[all_defaults["source"] == "Dendritic"]) == {labels.get_loc("Dendritic")}
+    assert set(target_idx[all_defaults["target"] == "Dendritic"]) == {labels.get_loc("Dendritic")}
+
+
+def test_positions_absent_gene(adata: AnnData, all_defaults: DataFrame) -> None:
+    unknown = all_defaults.copy()
+    unknown.loc[unknown.index[0], "ligand"] = "NOT_A_GENE"
+
+    with pytest.raises(KeyError, match="ligand\\(s\\) absent from `adata.var_names`: NOT_A_GENE"):
+        _get_mat_idx(adata, unknown)
+
+
+def test_perms_are_parallel_invariant(adata: AnnData) -> None:
+    serial = _get_means_perms(
+        adata=adata, norm_factor=None, aggregation="mean", n_perms=20, seed=1337, n_jobs=1, verbose=False
+    )
+    parallel = _get_means_perms(
+        adata=adata, norm_factor=None, aggregation="mean", n_perms=20, seed=1337, n_jobs=2, verbose=False
+    )
+
+    np.testing.assert_array_equal(serial, parallel)
 
 
 def test_cellchat_perms(adata: AnnData) -> None:
     mat_max = np.float32(get_x(adata).max())  # float32, as the pipeline computes it
 
     perms = _get_means_perms(
-        adata=adata, norm_factor=None, agg_fn=_trimean, n_perms=100, seed=1337, n_jobs=1, verbose=False
+        adata=adata, norm_factor=None, aggregation="trimean", n_perms=100, seed=1337, n_jobs=1, verbose=False
     )
 
     assert perms.shape == (100, 10, 765)
@@ -61,7 +81,7 @@ def test_cellchat_perms(adata: AnnData) -> None:
     np.testing.assert_almost_equal(expected, desired, decimal=3)
 
     perms = _get_means_perms(
-        adata=adata, norm_factor=mat_max, agg_fn=_trimean, n_perms=100, seed=1337, n_jobs=1, verbose=False
+        adata=adata, norm_factor=mat_max, aggregation="trimean", n_perms=100, seed=1337, n_jobs=1, verbose=False
     )
     desired = np.array(
         [

--- a/tests/plotting/test_annulus.py
+++ b/tests/plotting/test_annulus.py
@@ -1,11 +1,11 @@
 import pytest
 from anndata import AnnData
 
-from liana.plotting import annulus_plot
+from liana.plotting import annulus
 
 
-def test_annulus_plot(toy_spatial: AnnData) -> None:
-    annulus_plot(
+def test_annulus(toy_spatial: AnnData) -> None:
+    annulus(
         toy_spatial,
         spatial_key="spatial",
         radius_step=200,
@@ -15,4 +15,4 @@ def test_annulus_plot(toy_spatial: AnnData) -> None:
     )
 
     with pytest.raises(KeyError, match="not found in adata.obsm"):
-        annulus_plot(toy_spatial, spatial_key="missing_key")
+        annulus(toy_spatial, spatial_key="missing_key")

--- a/tests/plotting/test_circle_plot.py
+++ b/tests/plotting/test_circle_plot.py
@@ -4,7 +4,7 @@ from anndata import AnnData
 from pandas import DataFrame
 from tests._helpers import invalid
 
-from liana.plotting import circle_plot
+from liana.plotting import circle
 from liana.plotting._circle_plot import _get_adata_colors, _pivot_liana_res, _set_adata_color, get_mask_df
 
 
@@ -21,7 +21,7 @@ def adata(pbmc68k: AnnData, liana_res: DataFrame) -> AnnData:
 def test_circle_plot(adata: AnnData, liana_res: DataFrame) -> None:
     # circle_plot returns bare Axes, so assert on the adjacency it is built from:
     # 'mean' averages the score per source-target pair ...
-    circle_plot(adata, groupby="random", liana_res=liana_res, pivot_mode="mean", score_key="specificity_rank")
+    circle(adata, groupby="random", liana_res=liana_res, pivot_mode="mean", score_key="specificity_rank")
     means = _pivot_liana_res(liana_res, score_key="specificity_rank", mode="mean")
     expected = liana_res.groupby(["source", "target"])["specificity_rank"].mean()
     assert means.loc["A", "B"] == pytest.approx(expected.loc["A", "B"])
@@ -29,7 +29,7 @@ def test_circle_plot(adata: AnnData, liana_res: DataFrame) -> None:
     assert set(means.columns) == set(liana_res["target"])
 
     # ... while 'counts' counts the interactions surviving the filter
-    circle_plot(
+    circle(
         adata,
         groupby="random",
         liana_res=liana_res,
@@ -44,13 +44,13 @@ def test_circle_plot(adata: AnnData, liana_res: DataFrame) -> None:
 
 def test_circle_plot_raises(adata: AnnData, liana_res: DataFrame) -> None:
     with pytest.raises(ValueError, match="`groupby` must be provided"):
-        circle_plot(adata, groupby=None, liana_res=liana_res)
+        circle(adata, groupby=None, liana_res=liana_res)
 
     with pytest.raises(ValueError, match="`pivot_mode` must be 'counts' or 'mean'"):
-        circle_plot(adata, groupby="random", liana_res=liana_res, pivot_mode=invalid("neither"))
+        circle(adata, groupby="random", liana_res=liana_res, pivot_mode=invalid("neither"))
 
     with pytest.raises(ValueError, match="`score_key` must be provided"):
-        circle_plot(adata, groupby="random", liana_res=liana_res, pivot_mode="mean", score_key=None)
+        circle(adata, groupby="random", liana_res=liana_res, pivot_mode="mean", score_key=None)
 
 
 def test_get_mask_df(liana_res: DataFrame) -> None:

--- a/tests/plotting/test_lric_plot.py
+++ b/tests/plotting/test_lric_plot.py
@@ -8,7 +8,7 @@ from tests._helpers import get_obs, not_none, plot_data
 from liana.datasets import generate_toy_spatial
 from liana.datasets._sample_resource import sample_resource
 from liana.method.sp._LRIC import cross_pcf, lric
-from liana.plotting import lric_divergence_plot, lric_lineplot
+from liana.plotting import lric_divergence, lric_lineplot
 
 
 class _RadiusKwargs(TypedDict):
@@ -83,7 +83,7 @@ def test_max_dist_restricts_the_plotted_radii(adata: AnnData) -> None:
 def test_divergence_plot(adata: AnnData) -> None:
     two = adata.uns["cross_pcf"]["interaction"].unique()[:2]
     p = not_none(
-        lric_divergence_plot(
+        lric_divergence(
             adata,
             "cross_pcf",
             feature_a={"interaction": two[0]},
@@ -96,7 +96,7 @@ def test_divergence_plot(adata: AnnData) -> None:
     # both curves are drawn
     assert plot_data(p)["curve"].nunique() == 2
     # `liana_res=` is accepted in place of an AnnData
-    lric_divergence_plot(
+    lric_divergence(
         liana_res=adata.uns["cross_pcf"],
         feature_a={"interaction": two[0]},
         feature_b={"interaction": two[1]},
@@ -107,7 +107,7 @@ def test_divergence_plot(adata: AnnData) -> None:
 
 def test_divergence_plot_bad_selection_raises(adata: AnnData) -> None:
     with pytest.raises(ValueError, match="No rows match"):
-        lric_divergence_plot(
+        lric_divergence(
             adata,
             "cross_pcf",
             feature_a={"interaction": "nope^nope"},

--- a/tests/plotting/test_misty_plots.py
+++ b/tests/plotting/test_misty_plots.py
@@ -1,3 +1,5 @@
+from contextlib import suppress
+
 import pandas as pd
 import pytest
 from anndata import AnnData
@@ -182,10 +184,11 @@ def test_contributions_filter_on_categorical_target(target_metrics: DataFrame) -
     ],
 )
 def test_renamed_plots_still_resolve(deprecated: str, current: str) -> None:
-    with pytest.warns(FutureWarning, match=f"use `liana.pl.{current}` instead"):
-        assert getattr(pl, deprecated) is getattr(pl, current)
+    alias = getattr(pl, deprecated)
 
+    assert f"Use `liana.pl.{current}` instead" in alias.__deprecated__
+    assert not hasattr(getattr(pl, current), "__deprecated__")
 
-def test_unknown_plot_raises() -> None:
-    with pytest.raises(AttributeError, match="has no attribute 'not_a_plot'"):
-        _ = pl.not_a_plot
+    # the alias forwards, so the call fails on the real signature *after* it has warned
+    with pytest.warns(FutureWarning, match=f"{deprecated} is deprecated"), suppress(TypeError, ValueError):
+        alias()

--- a/tests/plotting/test_misty_plots.py
+++ b/tests/plotting/test_misty_plots.py
@@ -43,7 +43,7 @@ def interactions() -> DataFrame:
 
 
 def test_target_contributions_plot(misty: MistyData) -> None:
-    plot_data = _frame(pl.contributions(misty=misty))
+    plot_data = _frame(pl.misty_contributions(misty=misty))
 
     # melted to one row per target x view, with no target or view dropped
     targets = misty.uns["target_metrics"]["target"]
@@ -52,38 +52,40 @@ def test_target_contributions_plot(misty: MistyData) -> None:
     assert plot_data.shape[0] == len(targets) * 2
 
     # `return_fig=False` draws the plot instead of handing it back
-    assert pl.contributions(misty=misty, return_fig=False) is None
+    assert pl.misty_contributions(misty=misty, return_fig=False) is None
 
 
 def test_target_metrics_plot(misty: MistyData) -> None:
     target_metrics = misty.uns["target_metrics"]
 
-    plot_data = _frame(pl.target_metrics(misty=misty, stat="gain_R2"))
+    plot_data = _frame(pl.misty_target_metrics(misty=misty, stat="gain_R2"))
     assert set(plot_data["target"]) == set(target_metrics["target"])
 
     # top_n keeps the n best targets by the statistic asked for
-    top = _frame(pl.target_metrics(misty=misty, stat="gain_R2", top_n=1))
+    top = _frame(pl.misty_target_metrics(misty=misty, stat="gain_R2", top_n=1))
     best = target_metrics.loc[target_metrics["gain_R2"].idxmax(), "target"]
     assert set(top["target"]) == {best}
 
-    filtered = _frame(pl.target_metrics(misty=misty, stat="gain_R2", filter_fn=lambda x: x["multi_R2"] > 0.5))
+    filtered = _frame(pl.misty_target_metrics(misty=misty, stat="gain_R2", filter_fn=lambda x: x["multi_R2"] > 0.5))
     expected = target_metrics[target_metrics["multi_R2"] > 0.5]["target"]
     assert 0 < len(expected) < len(target_metrics)  # else the check below is vacuous
     assert set(filtered["target"]) == set(expected)
 
-    assert pl.target_metrics(misty=misty, stat="gain_R2", return_fig=False) is None
+    assert pl.misty_target_metrics(misty=misty, stat="gain_R2", return_fig=False) is None
 
 
 def test_interactions_plot(misty: MistyData, interactions: DataFrame) -> None:
-    pl.interactions(misty=misty, top_n=3, view="extra", key=abs, ascending=False)
-    plot_data = _frame(pl.interactions(interactions=interactions, view="extra", filter_fn=lambda x: x["group"] == "b"))
+    pl.misty_interactions(misty=misty, top_n=3, view="extra", key=abs, ascending=False)
+    plot_data = _frame(
+        pl.misty_interactions(interactions=interactions, view="extra", filter_fn=lambda x: x["group"] == "b")
+    )
     assert plot_data.shape[0] == 3
 
-    assert pl.interactions(misty=misty, view="extra", return_fig=False) is None
+    assert pl.misty_interactions(misty=misty, view="extra", return_fig=False) is None
 
 
 def test_target_metrics_aggregate(target_metrics: DataFrame) -> None:
-    plot_data = _frame(pl.target_metrics(target_metrics=target_metrics, stat="gain_R2", aggregate_fn="mean"))
+    plot_data = _frame(pl.misty_target_metrics(target_metrics=target_metrics, stat="gain_R2", aggregate_fn="mean"))
 
     # every group is kept - aggregation only decides the order the targets
     # are drawn in, best mean first
@@ -94,7 +96,7 @@ def test_target_metrics_aggregate(target_metrics: DataFrame) -> None:
 
 def test_contributions_aggregate(target_metrics: DataFrame) -> None:
     plot_data = _frame(
-        pl.contributions(target_metrics=target_metrics, view_names=["intra", "extra"], aggregate_fn="median")
+        pl.misty_contributions(target_metrics=target_metrics, view_names=["intra", "extra"], aggregate_fn="median")
     )
 
     n_targets = target_metrics["target"].nunique()
@@ -105,7 +107,7 @@ def test_contributions_aggregate(target_metrics: DataFrame) -> None:
 
 
 def test_interactions_aggregate(interactions: DataFrame) -> None:
-    plot_data = _frame(pl.interactions(interactions=interactions, view="intra", aggregate_fn="sum"))
+    plot_data = _frame(pl.misty_interactions(interactions=interactions, view="intra", aggregate_fn="sum"))
 
     # only the requested view is drawn, with importances summed over the groups
     intra = interactions[interactions["view"] == "intra"]
@@ -117,30 +119,30 @@ def test_interactions_aggregate(interactions: DataFrame) -> None:
 
 def test_misty_plots_raise_without_data() -> None:
     with pytest.raises(ValueError, match="Provide either a misty object or a target_metrics"):
-        pl.target_metrics(stat="gain_R2")
+        pl.misty_target_metrics(stat="gain_R2")
 
     with pytest.raises(ValueError, match="Provide either a misty object or a target_metrics"):
-        pl.contributions(view_names=["intra", "extra"])
+        pl.misty_contributions(view_names=["intra", "extra"])
 
     with pytest.raises(ValueError, match="Provide either a misty object or interactions"):
-        pl.interactions(view="intra")
+        pl.misty_interactions(view="intra")
 
 
 def test_misty_plots_raise_on_missing_args(
     misty: MistyData, target_metrics: DataFrame, interactions: DataFrame
 ) -> None:
     with pytest.raises(ValueError, match="Provide a statistic to plot"):
-        pl.target_metrics(misty=misty, stat=None)
+        pl.misty_target_metrics(misty=misty, stat=None)
 
     with pytest.raises(ValueError, match="Provide a list of view names to plot"):
-        pl.contributions(target_metrics=target_metrics)
+        pl.misty_contributions(target_metrics=target_metrics)
 
     with pytest.raises(ValueError, match="Provide a ``view`` to plot"):
-        pl.interactions(interactions=interactions, view=None)
+        pl.misty_interactions(interactions=interactions, view=None)
 
 
 def test_contributions_filter(misty: MistyData) -> None:
-    plot_data = _frame(pl.contributions(misty=misty, filter_fn=lambda x: x["multi_R2"] > 0.5))
+    plot_data = _frame(pl.misty_contributions(misty=misty, filter_fn=lambda x: x["multi_R2"] > 0.5))
 
     target_metrics = misty.uns["target_metrics"]
     expected = target_metrics[target_metrics["multi_R2"] > 0.5]["target"]
@@ -151,14 +153,14 @@ def test_contributions_filter(misty: MistyData) -> None:
 def test_contributions_drops_intra_when_absent(misty: MistyData) -> None:
     # `intra` is dropped from the views when it is not among the metrics
     del misty.uns["target_metrics"]["intra"]
-    plot_data = _frame(pl.contributions(misty=misty))
+    plot_data = _frame(pl.misty_contributions(misty=misty))
     assert set(plot_data["view"]) == {"extra"}
 
 
 def test_contributions_filter_on_categorical_target(target_metrics: DataFrame) -> None:
     target_metrics["target"] = target_metrics["target"].astype("category")
     plot_data = _frame(
-        pl.contributions(
+        pl.misty_contributions(
             target_metrics=target_metrics,
             view_names=["intra", "extra"],
             aggregate_fn="mean",
@@ -166,3 +168,24 @@ def test_contributions_filter_on_categorical_target(target_metrics: DataFrame) -
         )
     )
     assert "a" not in set(plot_data["target"].cat.categories)
+
+
+@pytest.mark.parametrize(
+    ("deprecated", "current"),
+    [
+        ("contributions", "misty_contributions"),
+        ("interactions", "misty_interactions"),
+        ("target_metrics", "misty_target_metrics"),
+        ("circle_plot", "circle"),
+        ("annulus_plot", "annulus"),
+        ("lric_divergence_plot", "lric_divergence"),
+    ],
+)
+def test_renamed_plots_still_resolve(deprecated: str, current: str) -> None:
+    with pytest.warns(FutureWarning, match=f"use `liana.pl.{current}` instead"):
+        assert getattr(pl, deprecated) is getattr(pl, current)
+
+
+def test_unknown_plot_raises() -> None:
+    with pytest.raises(AttributeError, match="has no attribute 'not_a_plot'"):
+        _ = pl.not_a_plot


### PR DESCRIPTION
Fixes spatial proximity weighting, which cancelled out of the permutation p-values and so never affected them, and replaces the permutation nulls, the interaction index lookup and LRIC's weighted numerator with numba kernels (8-15x on the hot paths). Also splits `liana_pipe` into named stages with its own consensus entry point, and settles `liana.pl` on one naming convention with `FutureWarning` shims for the old names.
