### PR TITLE
Ban `pyplot.show` in the library

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ### Changed
 
+- **`matplotlib.pyplot.show` is banned in `src`.** The hang fixed in `li.pl.annulus` was invisible to CI, which runs headless and so turns `show` into a no-op -- the call only blocks where someone has a display. A lint rule catches the next one at the point it is written rather than at the point a user runs it.
+
+### Changed
+
 - **LRIC groups its edge list by counting sort.** The group key is a cell-type pair crossed with a radius tile, so it spans a few hundred values over tens of millions of edges; placing each edge in one pass beats paying a factor of `log(n_edges)` for the same order. Ascending traversal keeps ties in input order, so the result matches the stable sort it replaces exactly, and the group offsets fall out of the histogram rather than a second search over the sorted keys. `li.mt.lric(groupby=...)` goes from 5.4 s to 3.2 s on 14k spots over 36M edges.
 
 - **Binning that edge list no longer doubles peak memory.** Dropping self-pairs, assigning tiles and compacting used to be a chain of numpy expressions, each allocating a full-length intermediate; one pass that counts and then fills allocates only what it returns. Peak drops from 1954 MB to 1013 MB for the same 579 MB of edges, and the result is unchanged.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -205,9 +205,6 @@ lint.ignore = [
 lint.per-file-ignores."*/__init__.py" = [ "F401" ]
 lint.per-file-ignores."docs/*" = [ "I" ]
 lint.per-file-ignores."tests/*" = [ "D" ]
-# Showing from inside a library takes the decision away from the caller, and under an
-# interactive backend it blocks in the GUI event loop -- a hang CI never sees, because a
-# headless backend turns `show` into a no-op.
 lint.flake8-tidy-imports.banned-api."matplotlib.pyplot.show".msg = "return the figure instead; showing is the caller's decision"
 lint.pydocstyle.convention = "numpy"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -205,6 +205,10 @@ lint.ignore = [
 lint.per-file-ignores."*/__init__.py" = [ "F401" ]
 lint.per-file-ignores."docs/*" = [ "I" ]
 lint.per-file-ignores."tests/*" = [ "D" ]
+# Showing from inside a library takes the decision away from the caller, and under an
+# interactive backend it blocks in the GUI event loop -- a hang CI never sees, because a
+# headless backend turns `show` into a no-op.
+lint.flake8-tidy-imports.banned-api."matplotlib.pyplot.show".msg = "return the figure instead; showing is the caller's decision"
 lint.pydocstyle.convention = "numpy"
 
 [tool.mypy]

--- a/src/liana/_core/_pipe_utils/_get_mean_perms.py
+++ b/src/liana/_core/_pipe_utils/_get_mean_perms.py
@@ -396,10 +396,6 @@ def _calculate_pvals(
     lr_perm_means = _score_fn(perm_stats, axis=0)
     n_perms = perm_stats.shape[1]
 
-    # A permutation that leaves a cluster's membership unchanged -- the only possibility
-    # when a sample carries a single cluster -- has to score exactly as the observation
-    # does. The two sides are accumulated by different routines, so that tie survives only
-    # if it is compared within the tolerance of the single precision they are stored in.
     exceeds = np.greater_equal(lr_perm_means, lr_truth) | np.isclose(lr_perm_means, lr_truth, rtol=_TIE_RTOL, atol=0.0)
 
     return np.asarray(np.sum(exceeds, axis=0) / n_perms)

--- a/src/liana/method/sp/_LRIC.py
+++ b/src/liana/method/sp/_LRIC.py
@@ -826,9 +826,6 @@ class LRIC:
         assert_covered(np.union1d(resource["ligand"], resource["receptor"]), adata.var_names, verbose=verbose)
 
         if pair_chunk is not None:
-            # `scverse_misc.deprecated_arg` would fit here, but it retypes the method as a
-            # plain callable, so every `lric(adata, ...)` call site loses its `self` binding
-            # under a type checker.
             warn(
                 f"The argument pair_chunk is deprecated and will be removed in the future. {_PAIR_CHUNK_DEPRECATION}",
                 FutureWarning,

--- a/src/liana/plotting/_annulus.py
+++ b/src/liana/plotting/_annulus.py
@@ -153,6 +153,6 @@ def annulus(
         ncol=2,
     )
 
-    plt.tight_layout()
+    fig.tight_layout()
 
     return fig if return_fig else None

--- a/tests/method/sc/test_methods.py
+++ b/tests/method/sc/test_methods.py
@@ -262,5 +262,4 @@ def test_spatial_key_weights_pvals(toy_spatial: AnnData) -> None:
     merged = unweighted.merge(weighted, on=keys, suffixes=("_unweighted", "_weighted"))
 
     assert not merged["cellphone_pvals_unweighted"].equals(merged["cellphone_pvals_weighted"])
-    # down-weighting the observed score alone can only make it harder to beat the null
     assert (merged["cellphone_pvals_weighted"] >= merged["cellphone_pvals_unweighted"]).all()

--- a/tests/plotting/test_misty_plots.py
+++ b/tests/plotting/test_misty_plots.py
@@ -189,6 +189,5 @@ def test_renamed_plots_still_resolve(deprecated: str, current: str) -> None:
     assert f"Use `liana.pl.{current}` instead" in alias.__deprecated__
     assert not hasattr(getattr(pl, current), "__deprecated__")
 
-    # the alias forwards, so the call fails on the real signature *after* it has warned
     with pytest.warns(FutureWarning, match=f"{deprecated} is deprecated"), suppress(TypeError, ValueError):
         alias()


### PR DESCRIPTION
Bans `matplotlib.pyplot.show` in `src` via the `TID` rules the project already selects, so the class of bug just fixed in `li.pl.annulus` is caught when it is written rather than when a user with a display runs it — CI is headless, where `show` is a no-op. Also switches that function's `plt.tight_layout()` to act on the figure it built rather than on whichever one is current.
